### PR TITLE
Fix the max-width extended srcset example

### DIFF
--- a/UseCaseComparisons.md
+++ b/UseCaseComparisons.md
@@ -15,7 +15,7 @@ Assuming three image “breakpoints” based on maximum widths, using pixel-base
 
 **Extended `srcset`**
 ```
-<img src="image1.jpg" srcset="image1.jpg, image1.jpg 400w, image2.jpg 600w" alt="">
+<img src="image1.jpg" srcset="image1.jpg 400w, image2.jpg 600w, image3.jpg 800w" alt="">
 ```
 
 


### PR DESCRIPTION
As far as I can tell from the [srcset proposal](http://www.w3.org/html/wg/drafts/srcset/w3c-srcset/#additions-to-the-img-element), the width and height of the image candidate strings are to be interpreted as 'max-width' and 'max-height'.

This change updates the max-width example to reflect this interpretation and makes the example consistent with further examples ('Display density in conjunction with viewport sizing').
