### PR TITLE
Rewrote img-to-p fallback in the examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,8 +369,7 @@ span.note, span.issue {
    &lt;source media="(min-width: 45em)" src="large.jpg"&gt;
    &lt;source media="(min-width: 18em)" src="med.jpg"&gt;
    &lt;source src="small.jpg"&gt;
-   &lt;img src="small.jpg" alt=""&gt;
-   &lt;p&gt;Accessible text&lt;/p&gt;
+   &lt;img src="small.jpg" alt="Accessible text"&gt;
 &lt;/picture&gt;</pre>
 </div>
 <div class="issue">
@@ -386,8 +385,7 @@ span.note, span.issue {
    &lt;source media="(min-width: 45em)" srcset="large-1.jpg 1x, large-2.jpg 2x"&gt;
    &lt;source media="(min-width: 18em)" srcset="med-1.jpg 1x, med-2.jpg 2x"&gt;
    &lt;source srcset="small-1.jpg 1x, small-2.jpg 2x"&gt;
-   &lt;img src="small-1.jpg" alt=""&gt;
-   &lt;p&gt;Accessible text&lt;/p&gt;
+   &lt;img src="small.jpg" alt="Accessible text"&gt;
 &lt;/picture&gt;</pre>
 </div>
 <h3 id="relationship-to-srcset"><span class="secno">1.2 </span>Relationship to <code>srcset</code></h3>

--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@ span.note, span.issue {
    &lt;source media="(min-width: 45em)" src="large.jpg"&gt;
    &lt;source media="(min-width: 18em)" src="med.jpg"&gt;
    &lt;source src="small.jpg"&gt;
-   &lt;img src="small.jpg" alt="Accessible text"&gt;
+   &lt;p&gt;Accessible &lt;strong&gt;and rich&lt;/strong&gt; text&lt;/p&gt;
 &lt;/picture&gt;</pre>
 </div>
 <div class="issue">
@@ -385,7 +385,7 @@ span.note, span.issue {
    &lt;source media="(min-width: 45em)" srcset="large-1.jpg 1x, large-2.jpg 2x"&gt;
    &lt;source media="(min-width: 18em)" srcset="med-1.jpg 1x, med-2.jpg 2x"&gt;
    &lt;source srcset="small-1.jpg 1x, small-2.jpg 2x"&gt;
-   &lt;img src="small.jpg" alt="Accessible text"&gt;
+   &lt;p&gt;Accessible &lt;strong&gt;and rich&lt;/strong&gt; text&lt;/p&gt;
 &lt;/picture&gt;</pre>
 </div>
 <h3 id="relationship-to-srcset"><span class="secno">1.2 </span>Relationship to <code>srcset</code></h3>


### PR DESCRIPTION
Usually I can either see the image or its @alt. The examples assumed that if line 1 doesn't apply, then line 2; if line 2 doesn't apply, then line 3, etc., (which is the proper way for this kind of stacked markup, granted). Thus the examples said somehow: if you don't display images using the img tab, then fall back to next line and display the paragraph. This is not the proper way things work, I think. Hoping I'm not too much intruding here, but I felt like helping on this issue. Please feel free to get in touch if I'm missing the point entirely.
