### PR TITLE
Fixed latest W3C version link

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
             Latest W3C Published Version:
           </dt>
           <dd>
-            <a href="http://www.w3.org/TR/picture-element/">http://www.w3.org/TR/picture-element/</a>
+            <a href="http://www.w3.org/TR/html-picture-element/">http://www.w3.org/TR/html-picture-element/</a>
           </dd>
           <dd>
             <a href="http://picture.responsiveimages.org">http://picture.responsiveimages.org</a>


### PR DESCRIPTION
Following Ian Jacob's comment, fixed the link leading from picture.responsiveimages.org to the latest W3C version.
