### PR TITLE
Added a lazyload attr to the fallback examples, with a note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html><head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+<!DOCTYPE html><html><head>
+    <meta charset=utf-8>
+    <meta content="width=device-width,initial-scale=1" name=viewport>
     <title>
       The picture element
     </title>
@@ -288,189 +288,282 @@
         color: white;
     }
     </style>
-    <link rel="stylesheet" href="http://www.w3.org/StyleSheets/TR/W3C-ED">
+    <link href=http://www.w3.org/StyleSheets/TR/W3C-[STATUS] rel=stylesheet>
     <!--[if lt IE 9]><script src='http://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
 
-    <link class="ricg" rel="stylesheet" href="http://www.w3.org/StyleSheets/TR/w3c-unofficial.css">
+    <style class="w3c ricg">
+.w3c{
+                border: 1px solid blue;
+        }
+
+    .ricg{
+                border: 1px solid red;
+    }
+
+    span, cite{
+        border: 1px dotted green;
+    }
+    span span{
+        background-color: red;
+    }
+    </style>
+    <link href=http://www.w3.org/StyleSheets/TR/W3C-[STATUS] class=w3c rel=stylesheet>
+    <link href=http://www.w3.org/StyleSheets/TR/w3c-unofficial.css class=ricg rel=stylesheet>
   </head>
   <body>
     <header>
-      <div class="head">
+      <div class=head>
         <p>
-          <a href="http://responsiveimages.org"><img alt="Responsive Images Community Group" src="https://raw.github.com/ResponsiveImagesCG/meta/master/logo/Web/RICG_logo_small.png" style="float:right"></a> <a href="http://www.w3.org/"><img alt="W3C" height="48" width="72" src="http://www.w3.org/Icons/w3c_home"></a>
+          <a href=http://responsiveimages.org><img src=https://raw.github.com/ResponsiveImagesCG/meta/master/logo/Web/RICG_logo_small.png alt="Responsive Images Community Group" style=float:right></a> <a href=http://www.w3.org/><img src=http://www.w3.org/Icons/w3c_home alt=W3C height=48 width=72></a>
         </p>
         <h1>
           The picture element
         </h1>
-        <h2 class="no-num no-toc" id="an-html-extension-for-adaptive-images">
+        <h2 class="no-num no-toc" id=an-html-extension-for-adaptive-images>
           An HTML extension for adaptive images
         </h2>
-        <h2 class="no-num no-toc ricg" id="living-document-last-updated-22-may-2013">
-          Living document - Last updated 22 May 2013
+        <h2 class="no-num no-toc w3c" id=w3c-working-draft-22-august-2013>
+          W3C Working Draft 22 August 2013
+        </h2>
+        <h2 class="no-num no-toc ricg" id=living-document-last-updated-22-august-2013>
+          Living document - Last updated 22 August 2013
         </h2>
         <dl>
           <dt>
             This Version:
           </dt>
-          <dd class="ricg">
-            <a href="http://picture.responsiveimages.org/">http://picture.responsiveimages.org/</a>
+          <dd class=ricg>
+            <a href=http://picture.responsiveimages.org/>http://picture.responsiveimages.org/</a>
           </dd>
-          <dt class="ricg">
+          <dd class=w3c>
+            <a href=[VERSION]>[VERSION]</a>
+          </dd>
+          <dt class=w3c>
+            Latest version:
+          </dt>
+          <dt class=ricg>
             Latest W3C Published Version:
           </dt>
           <dd>
-            <a href="http://www.w3.org/TR/html-picture-element/">http://www.w3.org/TR/html-picture-element/</a>
+            <a href=http://www.w3.org/TR/[SHORTNAME]/>http://www.w3.org/TR/[SHORTNAME]/</a>
           </dd>
+          <dt class=w3c>
+            Previous version:
+          </dt>
+          <dd class=w3c>
+            None.
+          </dd>
+          <dt class=w3c>
+            Latest Editor's draft:
+          </dt>
           <dd>
-            <a href="http://picture.responsiveimages.org">http://picture.responsiveimages.org</a>
+            <a href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a>
           </dd>
           <dt>
             Participate:
           </dt>
           <dd>
-            <a href="http://w3c.responsiveimages.org">Join the Responsive
+            <a href=http://w3c.responsiveimages.org>Join the Responsive
             Images Community Group</a>
           </dd>
           <dd>
-            <a href="http://list.responsiveimages.org">Public mailing list</a>
+            <a href=http://list.responsiveimages.org>Public mailing list</a>
           </dd>
           <dd>
-            <a href="irc://irc.w3.org:6665/#respimg">IRC: #respimg on W3C's IRC
+            <a href=irc://irc.w3.org:6665/#respimg>IRC: #respimg on W3C's IRC
             server</a>
           </dd>
           <dd>
-            <a href="https://twitter.com/respimg">Twitter</a>
+            <a href=https://twitter.com/respimg>Twitter</a>
           </dd>
           <dd>
-            <a href="http://gh.responsiveimages.org">Github</a>
+            <a href=http://gh.responsiveimages.org>Github</a>
           </dd>
           <dt>
             Version history:
           </dt>
           <dd>
-            <a href="https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages">
-            Github commits</a> (<a href="https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages.atom">RSS</a>)
+            <a href=https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages>
+            Github commits</a> (<a href=https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages.atom>RSS</a>)
           </dd>
           <dd>
-            <a href="https://twitter.com/respimg_commits">Github commits on
+            <a href=https://twitter.com/respimg_commits>Github commits on
             Twitter</a>
           </dd>
           <dt>
             Authors:
           </dt>
           <dd>
-            <span>Participants</span> of the Responsive Images Community Group
+            <a href=#participants-0>Participants</a> of the Responsive Images Community Group
           </dd>
           <dt>
             Editors:
           </dt>
           <dd>
-            <a href="http://marcosc.com">Marcos Cáceres</a>, <a href="http://datadriven.com.au">Data.Driven</a>
+            <a href=http://marcosc.com>Marcos Cáceres</a>, <a href=http://datadriven.com.au>Data.Driven</a>
           </dd>
           <dd>
-            <a href="http://matmarquis.com/">Mat Marquis</a>
+            <a href=http://matmarquis.com/>Mat Marquis</a>
           </dd>
           <dd>
-            <a href="http://blog.yoav.ws/">Yoav Weiss</a>
+            <a href=http://blog.yoav.ws/>Yoav Weiss</a>
           </dd>
           <dd>
-            Adrian Bateman, <a href="http://www.microsoft.com/">Microsoft
+            Adrian Bateman, <a href=http://www.microsoft.com/>Microsoft
             Corporation</a>
           </dd>
           <dt>
             RICG Final Specification Licensing Commitments:
           </dt>
           <dd>
-            <a href="http://www.w3.org/community/respimg/spec/26/commitments">http://www.w3.org/community/respimg/spec/26/commitments</a>
+            <a href=http://www.w3.org/community/respimg/spec/26/commitments>http://www.w3.org/community/respimg/spec/26/commitments</a>
           </dd>
         </dl>
+        <p class="copyright w3c">
+          <a href=http://www.w3.org/Consortium/Legal/ipr-notice#Copyright>Copyright</a>
+          © 2013 <a href=http://www.w3.org/><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href=http://www.csail.mit.edu/><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href=http://www.ercim.eu/><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+          <a href=http://www.keio.ac.jp/>Keio</a>), All Rights Reserved. W3C
+          <a href=http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer>liability</a>,
+          <a href=http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks>trademark</a>
+          and <a href=http://www.w3.org/Consortium/Legal/copyright-documents>document
+          use</a> rules apply.
+        </p>
         <p class="copyright ricg">
           Copyright © 2013 the Contributors to the <cite>Use Cases and
           Requirements for Standardizing Responsive Images</cite>
-          Specification, published by the <a href="http://www.w3.org/community/respimg/">Responsive Images Community
-          Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community
-          Contributor License Agreement (CLA)</a>. A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a>
+          Specification, published by the <a href=http://www.w3.org/community/respimg/>Responsive Images Community
+          Group</a> under the <a href=https://www.w3.org/community/about/agreements/cla/>W3C Community
+          Contributor License Agreement (CLA)</a>. A human-readable <a href=http://www.w3.org/community/about/agreements/cla-deed/>summary</a>
           is available.
         </p>
       </div>
       <hr>
     </header>
-    <h2 class="no-toc no-num" id="abstract">
+    <h2 class="no-toc no-num" id=abstract>
       Abstract
     </h2>
     <p>
-      The <code><a href="#dfn-picture">picture</a></code> element provides a way to group multiple
+      The <a href=#dfn-picture><code>picture</code></a> element provides a way to group multiple
       versions of an image based on different characteristics (e.g., format,
       resolution, cropping, etc.). This allows the user agent to select the
       optimum image to present to an end-user based on the user agent's
       environmental conditions and constraints.
     </p>
-    <h2 class="no-toc no-num" id="status">
+    <h2 class="no-toc no-num" id=status>
       Status of This Document
     </h2>
     <p>
       <em>This section describes the status of this document at the time of its
       publication. Other documents may supersede this document. A list of
       current W3C publications and the latest revision of this technical report
-      can be found in the <a href="http://www.w3.org/TR/">W3C technical reports
+      can be found in the <a href=http://www.w3.org/TR/>W3C technical reports
       index</a> at http://www.w3.org/TR/.</em>
     </p>
-    <p class="ricg">
-      This specification was published by the <a href="http://www.w3.org/community/respimg/">Responsive Images Community
+    <p class=ricg>
+      This specification was published by the <a href=http://www.w3.org/community/respimg/>Responsive Images Community
       Group</a>. It is not a W3C Standard nor is it on the W3C Standards Track.
-      Please note that under the <a href="http://www.w3.org/community/about/agreements/cla/">W3C Community
+      Please note that under the <a href=http://www.w3.org/community/about/agreements/cla/>W3C Community
       Contributor License Agreement (CLA)</a> there is a limited opt-out and
-      other conditions apply. Learn more about <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
+      other conditions apply. Learn more about <a href=http://www.w3.org/community/>W3C Community and Business Groups</a>.
     </p>
     <div class="note ricg">
-      <div class="note-title">
+      <div class=note-title>
         <span>Note</span>
       </div>
       <div class="">
         <p>
           This specification is under active development and changing
-          frequently. Please see the list of <a class="internalDFN" href="#dfn-open-issues">open issues</a>.
+          frequently. Please see the list of <a href=#dfn-open-issues class=internalDFN>open issues</a>.
         </p>
       </div>
     </div>
-    <h2 class="no-num no-toc" id="table-of-contents">
+    <div class=w3c>
+      <p id=wip class=stability>
+        <strong>This is a work in progress!</strong> For the latest updates
+        from the HTML WG and <a href=http://responsiveimages.org>RICG</a>,
+        possibly including important bug fixes, please look at the <a href=http://usecases.responsiveimages.org>editor's draft</a> instead. If
+        you find any bugs, typos, or issues please <a href="https://www.w3.org/Bugs/Public/enter_bug.cgi?product=HTML%20WG">file a
+        bug</a>! <input type=button onclick=closeWarning(this.parentNode) value=X>
+      </p><script>
+function closeWarning(element) {
+      element.parentNode.removeChild(element);
+      var date = new Date();
+      date.setDate(date.getDate()+4);
+      document.cookie = 'hide-obsolescence-warning=1; expires=' + date.toGMTString();
+      }
+      if (getCookie('hide-obsolescence-warning') == '1')
+      setTimeout(function () { document.getElementById('wip').parentNode.removeChild(document.getElementById('wip')); }, 2000);
+      </script>
+      <p>
+        This is a First Public Working Draft.
+      </p>
+      <p>
+        This document was published by the <a href=http://www.w3.org/html/wg/>HTML Working Group</a> as a Working Draft,
+        but was developed in collaboration with the <a href=http://responsiveimages.org>Responsive Images Community Group</a>
+        (see <a href=http://www.w3.org/community/respimg/spec/26/commitments>licensing
+        commitments</a>). If you are not a HTML working group member and wish
+        to make comments regarding this document please send them to <a href=mailto:public-html-comments@w3.org>public-html-comments@w3.org</a>
+        (<a href="mailto:public-html-comments-request@w3.org?subject=subscribe">subscribe</a>,
+        <a href=http://lists.w3.org/Archives/Public/public-html-comments/>archives</a>).
+        If you are a HTML working group member and wish to make comments
+        regarding this document, please send them to <a href=mailto:public-html@w3.org>public-html@w3.org</a> (<a href="mailto:public-html-request@w3.org?subject=subscribe">subscribe</a>,
+        <a href=http://lists.w3.org/Archives/Public/public-html/>archives</a>). All
+        feedback is welcome.
+      </p>
+      <p>
+        Publication as a Working Draft does not imply endorsement by the W3C
+        Membership. This is a draft document and may be updated, replaced or
+        obsoleted by other documents at any time. It is inappropriate to cite
+        this document as other than work in progress.
+      </p>
+      <p>
+        This document was produced by a group operating under the <a href=http://www.w3.org/Consortium/Patent-Policy-20040205/>5 February 2004
+        W3C Patent Policy</a>. W3C maintains a <a href=http://www.w3.org/2004/01/pp-impl/40318/status rel=disclosure>public list of any patent disclosures</a> made in
+        connection with the deliverables of the group; that page also includes
+        instructions for disclosing a patent. An individual who has actual
+        knowledge of a patent which the individual believes contains <a href=http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential>Essential
+        Claim(s)</a> must disclose the information in accordance with <a href=http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure>section
+        6 of the W3C Patent Policy</a>.
+      </p>
+    </div>
+    <h2 class="no-num no-toc" id=table-of-contents>
       Table of Contents
     </h2>
 <!--begin-toc-->
-<ol class="toc">
- <li><a href="#introduction"><span class="secno">1 </span>
+<ol class=toc>
+ <li><a href=#introduction><span class=secno>1 </span>
       Introduction
     </a>
-  <ol class="toc">
-   <li><a href="#example-of-usage"><span class="secno">1.1 </span>
+  <ol>
+   <li><a href=#example-of-usage><span class=secno>1.1 </span>
       Example of usage
     </a></li>
-   <li><a href="#relationship-to-srcset"><span class="secno">1.2 </span>
+   <li><a href=#relationship-to-srcset><span class=secno>1.2 </span>
       Relationship to <code>srcset</code>
-    </a></ol></li>
- <li><a href="#conformance"><span class="secno">2 </span>
+    </a></li></ol></li>
+ <li><a href=#conformance><span class=secno>2 </span>
       Conformance
     </a></li>
- <li><a href="#definitions"><span class="secno">3 </span>
+ <li><a href=#definitions><span class=secno>3 </span>
       Definitions
     </a></li>
- <li><a href="#the-picture-element"><span class="secno">4 </span>
+ <li><a href=#the-picture-element><span class=secno>4 </span>
       The <code>picture</code> element
     </a></li>
- <li><a href="#algorithm-for-deriving-the-source-image"><span class="secno">5 </span>
+ <li><a href=#algorithm-for-deriving-the-source-image><span class=secno>5 </span>
       Algorithm for deriving the source image
     </a></li>
- <li><a class="no-num" href="#open-issues">
+ <li><a href=#open-issues class=no-num>
       Open Issues
     </a></li>
- <li><a class="no-num" href="#acknowledgements">
+ <li><a href=#acknowledgements class=no-num>
       Acknowledgements
     </a></li>
- <li><a class="no-num" href="#normative-references">
+ <li><a href=#normative-references class=no-num>
       Normative references
-    </a></ol>
+    </a></li></ol>
 <!--end-toc-->
-    <h2 id="introduction"><span class="secno">1 </span>
+    <h2 id=introduction><span class=secno>1 </span>
       Introduction
     </h2>
     <p>
@@ -481,10 +574,10 @@
       sources for an image, and, through [<cite>CSS3-MEDIAQUERIES</cite>]
       (<cite>CSS Media Queries</cite>), it gives developers control as to when
       those images are to be presented to a user. This is achieved by
-      introducing a new <code><a href="#dfn-picture">picture</a></code> element to [<cite>HTML</cite>]
+      introducing a new <a href=#dfn-picture><code>picture</code></a> element to [<cite>HTML</cite>]
       that makes use of the <code>source</code> element. The
-      <code><a href="#dfn-picture">picture</a></code> element remains backwards compatible with legacy
-      user agents by degrading gracefully through <a href="#dfn-fallback-content">fallback content</a>
+      <a href=#dfn-picture><code>picture</code></a> element remains backwards compatible with legacy
+      user agents by degrading gracefully through <a href=#dfn-fallback-content>fallback content</a>
       (i.e., through the <code>img</code> element) while also potentially
       providing better accessibility than the existing <code>img</code>
       element.
@@ -493,8 +586,8 @@
       By relying on [<cite>CSS3-MEDIAQUERIES</cite>], a user agent can
       <em>respond</em> to changes in the browsing environment by selecting the
       image source that most closely matches the browsing environment - thus
-      embodying a technique known as <a href="http://en.wikipedia.org/wiki/Responsive_web_design">responsive web
-      design</a> directly in the HTML markup. <a href="http://www.w3.org/TR/css3-mediaqueries/#media1">Media features</a> that
+      embodying a technique known as <a href=http://en.wikipedia.org/wiki/Responsive_web_design>responsive web
+      design</a> directly in the HTML markup. <a href=http://www.w3.org/TR/css3-mediaqueries/#media1>Media features</a> that
       a user agent can potentially respond to include, but are not limited to,
       pixel widths and heights, and pixel densities, as well as environmental
       lighting conditions, changes in orientation, and changes in media type
@@ -503,65 +596,77 @@
     <p>
       This specification also defines the <code>HTMLPictureElement</code>
       programming interface, which affords developers a set of attributes and
-      methods for interacting with <code><a href="#dfn-picture">picture</a></code> elements through
+      methods for interacting with <a href=#dfn-picture><code>picture</code></a> elements through
       ECMAScript.
     </p>
-    <h3 id="example-of-usage"><span class="secno">1.1 </span>
+    <h3 id=example-of-usage><span class=secno>1.1 </span>
       Example of usage
     </h3>
     <p>
       <em>This section is non-normative.</em>
     </p>
     <p>
-      This first sample shows how to combine the <code><a href="#dfn-picture">picture</a></code> element
+      This first sample shows how to combine the <a href=#dfn-picture><code>picture</code></a> element
       with the source element, while also providing fallback content for legacy
       user agents through the <code>img</code> element.
     </p>
-    <div class="example">
-      <div class="example-title">
+    <div class=example>
+      <div class=example-title>
         <span>Example 1</span>
       </div>
-      <pre class="example">&lt;picture width="500" height="500"&gt;
+      <pre class=example>&lt;picture width="500" height="500"&gt;
    &lt;source media="(min-width: 45em)" src="large.jpg"&gt;
    &lt;source media="(min-width: 18em)" src="med.jpg"&gt;
    &lt;source src="small.jpg"&gt;
-   &lt;img src="small.jpg" alt=""&gt;
+   &lt;img src="small.jpg" alt="" lazyload&gt;
    &lt;p&gt;Accessible text&lt;/p&gt;
 &lt;/picture&gt;
 </pre>
     </div>
-    <div class="issue">
-      <div class="issue-title">
+    <div class=issue>
+      <div class=issue-title>
         <span>Issue 1</span>
       </div>
       <div class="">
         <p>
-          The following example assumes we can get <a href="http://dev.w3.org/html5/srcset/">the <code>srcset</code>
+          The following example assumes we can get <a href=http://dev.w3.org/html5/srcset/>the <code>srcset</code>
           attribute</a> supported on HTML's <code>source</code> element. See
-          <a href="https://github.com/Wilto/draft-prop/issues/64">issue 64</a>.
+          <a href=https://github.com/Wilto/draft-prop/issues/64>issue 64</a>.
         </p>
       </div>
     </div>
     <p>
-      This second example shows how the <code><a href="#dfn-picture">picture</a></code> element can be
-      used with <a href="http://dev.w3.org/html5/srcset/">the
+      This second example shows how the <a href=#dfn-picture><code>picture</code></a> element can be
+      used with <a href=http://dev.w3.org/html5/srcset/>the
       <code>srcset</code> attribute</a> to provide a range of sources suitable
       for a given media query:
     </p>
-    <div class="example">
-      <div class="example-title">
+    <div class=example>
+      <div class=example-title>
         <span>Example 2</span>
       </div>
-      <pre class="example">&lt;picture width="500" height="500"&gt;
+      <pre class=example>&lt;picture width="500" height="500"&gt;
    &lt;source media="(min-width: 45em)" srcset="large-1.jpg 1x, large-2.jpg 2x"&gt;
    &lt;source media="(min-width: 18em)" srcset="med-1.jpg 1x, med-2.jpg 2x"&gt;
    &lt;source srcset="small-1.jpg 1x, small-2.jpg 2x"&gt;
-   &lt;img src="small-1.jpg" alt=""&gt;
+   &lt;img src="small-1.jpg" alt="" lazyload&gt;
    &lt;p&gt;Accessible text&lt;/p&gt;
 &lt;/picture&gt;
 </pre>
     </div>
-    <h3 id="relationship-to-srcset"><span class="secno">1.2 </span>
+    <div class=note>
+      <div class=note-title>
+        <span>Note</span>
+      </div>
+      <div class="">
+        <p>
+        The <code>lazyload</code> attribute is used on the <code>&lt;img&gt;</code> tag in the above examples in order to avoid a download
+            of that resource when picture is supported.
+            It enables the user agent to delay the resource's download at least until the resource is added to the DOM, at which point the
+            user agent can detect that the <code>&lt;img&gt;</code> element is a child of a <code>&lt;picture&gt;</code> element.
+        </p>
+      </div>
+    <h3 id=relationship-to-srcset><span class=secno>1.2 </span>
       Relationship to <code>srcset</code>
     </h3>
     <p>
@@ -570,8 +675,8 @@
       image source to display. Given a set of image resources, the user agent
       has the option of either following or overriding the author’s
       declarations to optimize the user experience based on criteria such as
-      <a href="http://usecases.responsiveimages.org/#resolution-switching">display
-      density</a>, connection type, <a href="http://usecases.responsiveimages.org/#user-control-over-sources">user
+      <a href=http://usecases.responsiveimages.org/#resolution-switching>display
+      density</a>, connection type, <a href=http://usecases.responsiveimages.org/#user-control-over-sources>user
       preferences</a>, and so on.
     </p>
     <p>
@@ -579,18 +684,18 @@
       the author's explicit instructions when selecting which resource to
       display. This includes image sources with inherent sizes designed to
       align with layout variations specified in CSS media queries ( see:
-      <a href="http://usecases.responsiveimages.org/#design-breakpoints">design
-      breakpoints</a>, <a href="http://usecases.responsiveimages.org/#matching-media-features-and-media-types">
-      media features and types</a> and <a href="http://usecases.responsiveimages.org/#relative-units">relative units</a>
-      ) or <a href="http://usecases.responsiveimages.org/#art-direction">content variations
+      <a href=http://usecases.responsiveimages.org/#design-breakpoints>design
+      breakpoints</a>, <a href=http://usecases.responsiveimages.org/#matching-media-features-and-media-types>
+      media features and types</a> and <a href=http://usecases.responsiveimages.org/#relative-units>relative units</a>
+      ) or <a href=http://usecases.responsiveimages.org/#art-direction>content variations
       for increased clarity and focus</a> based on the client’s display size.
     </p>
     <p>
       The proposed solutions are not mutually exclusive, and may work together
-      to address the complete set of <a href="http://usecases.responsiveimages.org/">use cases and requirements for
+      to address the complete set of <a href=http://usecases.responsiveimages.org/>use cases and requirements for
       responsive images</a>.
     </p>
-    <h2 id="conformance"><span class="secno">2 </span>
+    <h2 id=conformance><span class=secno>2 </span>
       Conformance
     </h2>
     <p>
@@ -599,23 +704,23 @@
       Everything else in this specification is normative.
     </p>
     <p>
-      The key words <em class="rfc2119" title="must">must</em>, <em class="rfc2119" title="must not">must not</em>, <em class="rfc2119" title="required">required</em>, <em class="rfc2119" title="should">should</em>,
-      <em class="rfc2119" title="should not">should not</em>, <em class="rfc2119" title="recommended">recommended</em>, <em class="rfc2119" title="may">may</em>, and <em class="rfc2119" title="optional">optional</em> in this specification are to be interpreted as
-      described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+      The key words <em title=must class=rfc2119>must</em>, <em title="must not" class=rfc2119>must not</em>, <em title=required class=rfc2119>required</em>, <em title=should class=rfc2119>should</em>,
+      <em title="should not" class=rfc2119>should not</em>, <em title=recommended class=rfc2119>recommended</em>, <em title=may class=rfc2119>may</em>, and <em title=optional class=rfc2119>optional</em> in this specification are to be interpreted as
+      described in [<cite><a href=#bib-RFC2119 class=bibref>RFC2119</a></cite>].
     </p>
     <p>
-      This specification has the same <a href="http://dev.w3.org/html5/spec/single-page.html#conformance-requirements">conformance
-      requirements</a> and applies to the same <a href="http://dev.w3.org/html5/spec/single-page.html#conformance-classes">conformance
+      This specification has the same <a href=http://dev.w3.org/html5/spec/single-page.html#conformance-requirements>conformance
+      requirements</a> and applies to the same <a href=http://dev.w3.org/html5/spec/single-page.html#conformance-classes>conformance
       classes</a> as [<cite>HTML</cite>].
     </p>
     <p>
       Implementations that use ECMAScript to expose the APIs defined in this
-      specification <em class="rfc2119" title="must">must</em> implement them
+      specification <em title=must class=rfc2119>must</em> implement them
       in a manner consistent with the ECMAScript Bindings defined in the
-      [<cite><a class="bibref" href="#bib-WEBIDL">WEBIDL</a></cite>]
+      [<cite><a href=#bib-WEBIDL class=bibref>WEBIDL</a></cite>]
       specification.
     </p>
-    <h2 id="definitions"><span class="secno">3 </span>
+    <h2 id=definitions><span class=secno>3 </span>
       Definitions
     </h2>
     <p>
@@ -625,79 +730,79 @@
     </p>
     <p>
       The follow terms are defined by the [<cite>HTML</cite>] specification:
-      <dfn id="dfn-img-element"><a href="http://dev.w3.org/html5/spec/single-page.html#the-img-element"><code>img</code>
-      element</a></dfn>, <dfn id="dfn-source-element"><a href="http://dev.w3.org/html5/spec/single-page.html#the-source-element"><code>source</code>
-      element</a></dfn>, <dfn id="dfn-fallback-content"><a href="http://dev.w3.org/html5/spec/single-page.html#fallback-content">fallback
-      content</a></dfn>, and <dfn id="dfn-valid-media-query"><a href="http://dev.w3.org/html5/spec/single-page.html#valid-media-query">valid
+      <dfn id=dfn-img-element><a href=http://dev.w3.org/html5/spec/single-page.html#the-img-element><code>img</code>
+      element</a></dfn>, <dfn id=dfn-source-element><a href=http://dev.w3.org/html5/spec/single-page.html#the-source-element><code>source</code>
+      element</a></dfn>, <dfn id=dfn-fallback-content><a href=http://dev.w3.org/html5/spec/single-page.html#fallback-content>fallback
+      content</a></dfn>, and <dfn id=dfn-valid-media-query><a href=http://dev.w3.org/html5/spec/single-page.html#valid-media-query>valid
       media query</a></dfn>.
     </p>
-    <h2 id="the-picture-element"><span class="secno">4 </span>
-      The <code><a href="#dfn-picture">picture</a></code> element
+    <h2 id=the-picture-element><span class=secno>4 </span>
+      The <a href=#dfn-picture><code>picture</code></a> element
     </h2>
     <dl>
       <dt>
-        <a title="element-dfn-categories" href="http://dev.w3.org/html5/spec/single-page.html#element-dfn-categories">Categories</a>:
+        <a href=http://dev.w3.org/html5/spec/single-page.html#element-dfn-categories title=element-dfn-categories>Categories</a>:
       </dt>
       <dd>
-        <a href="http://dev.w3.org/html5/spec/single-page.html#flow-content-1">Flow
+        <a href=http://dev.w3.org/html5/spec/single-page.html#flow-content-1>Flow
         content</a>.
       </dd>
       <dd>
-        <a href="http://dev.w3.org/html5/spec/single-page.html#phrasing-content-1">Phrasing
+        <a href=http://dev.w3.org/html5/spec/single-page.html#phrasing-content-1>Phrasing
         content</a>.
       </dd>
       <dd>
-        <a href="http://dev.w3.org/html5/spec/single-page.html#embedded-content-2">Embedded
+        <a href=http://dev.w3.org/html5/spec/single-page.html#embedded-content-2>Embedded
         content</a>.
       </dd>
       <dd>
-        <a href="http://dev.w3.org/html5/spec/single-page.html#palpable-content-0">Palpable
+        <a href=http://dev.w3.org/html5/spec/single-page.html#palpable-content-0>Palpable
         content</a>.
       </dd>
       <dt>
-        <a title="element-dfn-contexts" href="http://dev.w3.org/html5/spec/single-page.html#element-dfn-contexts">Contexts in which this element can be
+        <a href=http://dev.w3.org/html5/spec/single-page.html#element-dfn-contexts title=element-dfn-contexts>Contexts in which this element can be
         used</a>:
       </dt>
       <dd>
-        Where <a href="http://dev.w3.org/html5/spec/single-page.html#embedded-content-2">embedded
+        Where <a href=http://dev.w3.org/html5/spec/single-page.html#embedded-content-2>embedded
         content</a> is expected.
       </dd>
       <dt>
-        <a title="element-dfn-content-model" href="http://dev.w3.org/html5/spec/single-page.html#element-dfn-content-model">Content model</a>:
+        <a href=http://dev.w3.org/html5/spec/single-page.html#element-dfn-content-model title=element-dfn-content-model>Content model</a>:
       </dt>
       <dd>
-        If zero descendents, then <a href="http://dev.w3.org/html5/spec/single-page.html#transparent">transparent</a>.
+        If zero descendents, then <a href=http://dev.w3.org/html5/spec/single-page.html#transparent>transparent</a>.
       </dd>
       <dd>
         One or more <code>source</code> elements.
       </dd>
       <dd>
-        Zero or one <code>img</code> element, serving as <a class="internalDFN" href="#dfn-fallback-content">fallback content</a>.
+        Zero or one <code>img</code> element, serving as <a href=#dfn-fallback-content class=internalDFN>fallback content</a>.
       </dd>
       <dt>
-        <a title="element-dfn-attributes" href="http://dev.w3.org/html5/spec/single-page.html#element-dfn-attributes">Content attributes</a>:
+        <a href=http://dev.w3.org/html5/spec/single-page.html#element-dfn-attributes title=element-dfn-attributes>Content attributes</a>:
       </dt>
       <dd>
-        <a href="http://dev.w3.org/html5/spec/single-page.html#global-attributes">Global
+        <a href=http://dev.w3.org/html5/spec/single-page.html#global-attributes>Global
         attributes</a>
       </dd>
       <dd>
-        <code title="attr-picture-alt"><a href="#attr-picture-alt">alt</a></code>
+        <code title=attr-picture-alt><a href=#attr-picture-alt>alt</a></code>
       </dd>
       <dd>
-        <code title="attr-picture-src"><a href="#attr-picture-src">src</a></code>
+        <code title=attr-picture-src><a href=#attr-picture-src>src</a></code>
       </dd>
       <dd>
-        <code title="attr-picture-srcset"><a href="#attr-picture-srcset">srcset</a></code>
+        <code title=attr-picture-srcset><a href=#attr-picture-srcset>srcset</a></code>
       </dd>
       <dd>
-        <code title="attr-picture-crossorigin"><a href="#attr-picture-crossorigin">crossorigin</a></code>
+        <code title=attr-picture-crossorigin><a href=#attr-picture-crossorigin>crossorigin</a></code>
       </dd>
       <dd>
-        <code title="attr-hyperlink-usemap"><a href="#attr-hyperlink-usemap">usemap</a></code>
+        <code title=attr-hyperlink-usemap><a href=#attr-hyperlink-usemap>usemap</a></code>
       </dd>
       <dd>
-        <code title="attr-picture-ismap"><a href="#attr-picture-ismap">ismap</a></code>
+        <code title=attr-picture-ismap><a href=#attr-picture-ismap>ismap</a></code>
       </dd>
       <dd>
         <code>width</code>
@@ -706,105 +811,105 @@
         <code>height</code>
       </dd>
       <dt>
-        <a title="element-dfn-dom" href="http://dev.w3.org/html5/spec/single-page.html#element-dfn-dom">DOM interface</a>:
+        <a href=http://dev.w3.org/html5/spec/single-page.html#element-dfn-dom title=element-dfn-dom>DOM interface</a>:
       </dt>
       <dd>
         <pre>[NamedConstructor=Picture,
  NamedConstructor=Picture(unsigned long width),
  NamedConstructor=Picture(unsigned long width, unsigned long height)]
 HTMLPictureElement : HTMLImageElement{
-   attribute DOMString <a title="dom-picture-alt" href="#dom-picture-alt">alt</a>;
-   attribute DOMString <a title="dom-picture-src" href="#dom-picture-src">src</a>;
-   attribute DOMString <a title="dom-picture-crossOrigin" href="#dom-picture-crossorigin">crossOrigin</a>;
-   attribute DOMString <a title="dom-picture-srcset" href="#dom-picture-srcset">srcset</a>;
-   readonly attribute DOMString <a title="dom-picture-currentsrc" href="#dom-picture-currentsrc">currentSrc</a>;
-   attribute DOMString <a title="dom-picture-useMap" href="#dom-picture-usemap">useMap</a>;
-   attribute boolean <a title="dom-picture-isMap" href="#dom-picture-ismap">isMap</a>;
+   attribute DOMString <a href=#dom-picture-alt title=dom-picture-alt>alt</a>;
+   attribute DOMString <a href=#dom-picture-src title=dom-picture-src>src</a>;
+   attribute DOMString <a href=#dom-picture-crossorigin title=dom-picture-crossOrigin>crossOrigin</a>;
+   attribute DOMString <a href=#dom-picture-srcset title=dom-picture-srcset>srcset</a>;
+   readonly attribute DOMString <a href=#dom-picture-currentsrc title=dom-picture-currentsrc>currentSrc</a>;
+   attribute DOMString <a href=#dom-picture-usemap title=dom-picture-useMap>useMap</a>;
+   attribute boolean <a href=#dom-picture-ismap title=dom-picture-isMap>isMap</a>;
    readonly attribute DOMString media;
-   void <a title="dom-picture-load" href="#dom-picture-load">load</a>();
+   void <a href=#dom-picture-load title=dom-picture-load>load</a>();
 }
 </pre>
       </dd>
     </dl>
     <p>
-      The <code><dfn id="dfn-picture">picture</dfn></code> element used for
+      The <code><dfn id=dfn-picture>picture</dfn></code> element used for
       displaying an image that can come from a range of sources (including the
-      <dfn id="attr-picture-src" title="attr-picture-src"><code>src</code></dfn> and <dfn id="attr-picture-srcset" title="attr-picture-srcset"><code>srcset</code></dfn> attributes). Which image
-      the user agent displays depends on the <a class="internalDFN" href="#dfn-algorithm-for-deriving-the-source-image">algorithm for deriving the source image</a>. The value of
-      the <dfn id="attr-picture-alt" title="attr-picture-alt"><code>alt</code></dfn> attribute provides equivalent
+      <dfn title=attr-picture-src id=attr-picture-src><code>src</code></dfn> and <dfn title=attr-picture-srcset id=attr-picture-srcset><code>srcset</code></dfn> attributes). Which image
+      the user agent displays depends on the <a href=#dfn-algorithm-for-deriving-the-source-image class=internalDFN>algorithm for deriving the source image</a>. The value of
+      the <dfn title=attr-picture-alt id=attr-picture-alt><code>alt</code></dfn> attribute provides equivalent
       content for those who cannot process images or who have image loading
       disabled.
     </p>
     <p>
-      The requirements on the <code title="attr-picture-alt"><a href="#attr-picture-alt">alt</a></code> attribute's value are described
-      <a href="http://www.w3.org/TR/html5/embedded-content-0.html#alt">in the
+      The requirements on the <code title=attr-picture-alt><a href=#attr-picture-alt>alt</a></code> attribute's value are described
+      <a href=http://www.w3.org/TR/html5/embedded-content-0.html#alt>in the
       <code>img</code> section</a>.
     </p>
     <p>
-      The <code title="attr-picture-src"><a href="#attr-picture-src">src</a></code> attribute may be present, and if
-      present must contain a <a href="http://www.w3.org/TR/html5/infrastructure.html#valid-non-empty-url-potentially-surrounded-by-spaces">
+      The <code title=attr-picture-src><a href=#attr-picture-src>src</a></code> attribute may be present, and if
+      present must contain a <a href=http://www.w3.org/TR/html5/infrastructure.html#valid-non-empty-url-potentially-surrounded-by-spaces>
       valid non-empty URL potentially surrounded by spaces</a> referencing a
-      non-interactive, optionally animated, <dfn id="image-resource">image resource</dfn> that is
+      non-interactive, optionally animated, <dfn id=image-resource>image resource</dfn> that is
       neither paged nor scripted.
     </p>
-    <p class="note">
+    <p class=note>
       The requirements above imply that images can be static bitmaps (e.g.
       PNGs, GIFs, JPEGs), single-page vector documents (single-page PDFs, XML
       files with an SVG root element), animated bitmaps (APNGs, animated GIFs),
       animated vector graphics (XML files with an SVG root element that use
       declarative SMIL animation), and so forth. However, these definitions
       preclude SVG files with script, multipage PDF files, interactive MNG
-      files, HTML documents, plain text documents, and so forth. <a href="http://www.w3.org/TR/html5/references.html#refsPNG">[PNG]</a> <a href="http://www.w3.org/TR/html5/references.html#refsGIF">[GIF]</a> <a href="http://www.w3.org/TR/html5/references.html#refsJPEG">[JPEG]</a> <a href="http://www.w3.org/TR/html5/references.html#refsPDF">[PDF]</a> <a href="http://www.w3.org/TR/html5/references.html#refsXML">[XML]</a> <a href="http://www.w3.org/TR/html5/references.html#refsAPNG">[APNG]</a> 
-      <!-- <a href="#refsAGIF">[AGIF]</a> --> <a href="http://www.w3.org/TR/html5/references.html#refsSVG">[SVG]</a> <a href="http://www.w3.org/TR/html5/references.html#refsMNG">[MNG]</a>
+      files, HTML documents, plain text documents, and so forth. <a href=http://www.w3.org/TR/html5/references.html#refsPNG>[PNG]</a> <a href=http://www.w3.org/TR/html5/references.html#refsGIF>[GIF]</a> <a href=http://www.w3.org/TR/html5/references.html#refsJPEG>[JPEG]</a> <a href=http://www.w3.org/TR/html5/references.html#refsPDF>[PDF]</a> <a href=http://www.w3.org/TR/html5/references.html#refsXML>[XML]</a> <a href=http://www.w3.org/TR/html5/references.html#refsAPNG>[APNG]</a> 
+      <!-- <a href="#refsAGIF">[AGIF]</a> --> <a href=http://www.w3.org/TR/html5/references.html#refsSVG>[SVG]</a> <a href=http://www.w3.org/TR/html5/references.html#refsMNG>[MNG]</a>
     </p>
     <p>
-      The <code title="attr-picture-srcset"><a href="#attr-picture-srcset">srcset</a></code> attribute may be present, and if
-      present must conform to <a href="http://dev.w3.org/html5/srcset/">the
+      The <code title=attr-picture-srcset><a href=#attr-picture-srcset>srcset</a></code> attribute may be present, and if
+      present must conform to <a href=http://dev.w3.org/html5/srcset/>the
       <code>srcset</code> specification</a>.
     </p>
-    <dl class="domintro">
+    <dl class=domintro>
       <dt>
-        <var><a href="#dfn-picture">picture</a></var> . <code>currentSrc</code>
+        <var>picture</var> . <code>currentSrc</code>
       </dt>
       <dd>
         <p>
-          Returns the address of the current <a href="#image-resource">image resource</a>.
+          Returns the address of the current <a href=#image-resource>image resource</a>.
         </p>
         <p>
-          Returns the empty string when there is no <a href="#image-resource">image
+          Returns the empty string when there is no <a href=#image-resource>image
           resource</a>.
         </p>
       </dd>
     </dl>
-    <div class="impl">
+    <div class=impl>
       <p>
-        The <dfn id="dom-picture-currentsrc" title="dom-picture-currentSrc"><code>currentSrc</code></dfn>
+        The <dfn title=dom-picture-currentSrc id=dom-picture-currentsrc><code>currentSrc</code></dfn>
         IDL attribute is initially the empty string. Its value is changed by
-        the <span title="dfn-algorithm-for-deriving-the-source-image">resource
+        the <span title=dfn-algorithm-for-deriving-the-source-image>resource
         selection algorithm</span> defined below.
       </p>
     </div>
-    <p class="note">
-      There are three ways to specify an <a href="#image-resource">image resource</a>, the
-      <code title="attr-picture-src"><a href="#attr-picture-src">src</a></code> attribute, the <code title="attr-picture-srcset"><a href="#attr-picture-srcset">srcset</a></code> attribute, or <code>source</code>
-      elements. The <code title="attr-picture-srcset"><a href="#attr-picture-srcset">srcset</a></code> attribute
-      overrides both the <code title="attr-picture-src"><a href="#attr-picture-src">src</a></code> attribute
-      and the elements; the <code title="attr-picture-src"><a href="#attr-picture-src">src</a></code> attribute
+    <p class=note>
+      There are three ways to specify an <a href=#image-resource>image resource</a>, the
+      <a href=#attr-picture-src><code title=attr-picture-src>src</code></a> attribute, the <a href=#attr-picture-srcset><code title=attr-picture-srcset>srcset</code></a> attribute, or <code>source</code>
+      elements. The <a href=#attr-picture-srcset><code title=attr-picture-srcset>srcset</code></a> attribute
+      overrides both the <a href=#attr-picture-src><code title=attr-picture-src>src</code></a> attribute
+      and the elements; the <a href=#attr-picture-src><code title=attr-picture-src>src</code></a> attribute
       overrides the elements.
     </p>
     <p>
-      The <dfn id="attr-picture-crossorigin" title="attr-picture-crossorigin"><code>crossorigin</code></dfn> attribute is a
-      <a href="http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attribute">CORS
+      The <dfn title=attr-picture-crossorigin id=attr-picture-crossorigin><code>crossorigin</code></dfn> attribute is a
+      <a href=http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attribute>CORS
       settings attribute</a>. Its purpose is to allow images from third-party
-      sites that allow cross-origin access to be used with <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-canvas-element">canvas</a></code>.
+      sites that allow cross-origin access to be used with <code><a href=http://www.w3.org/TR/html5/embedded-content-0.html#the-canvas-element>canvas</a></code>.
     </p>
     <p>
       On getting the <code>media</code> IDL attribute, the user agent
-      <em class="rfc2119" title="must">must</em> return the media query that
+      <em title=must class=rfc2119>must</em> return the media query that
       matches the current environment.
     </p>
     <p>
-      It is <em class="rfc2119" title="recommended">recommended</em> that for
+      It is <em title=recommended class=rfc2119>recommended</em> that for
       cases where a single image source is available, and where no responsive
       adoption is needed, authors use the <code>img</code> element. Authors can
       use the srcset attribute for simple resized image sources.
@@ -813,18 +918,18 @@ HTMLPictureElement : HTMLImageElement{
       The <span>chosen image</span> is the embedded content.
     </p>
     <p>
-      In the absence of style rules to the contrary, the chosen <a href="#image-resource">image
+      In the absence of style rules to the contrary, the chosen <a href=#image-resource>image
       resource</a> should be rendered centered within the element's area at
       the largest possible size that fits completely within the element's area,
-      with the chosen <a href="#image-resource">image resource</a>'s intrinsic aspect ratio
-      being preserved. Thus, if the aspect ratio of the <code><a href="#dfn-picture">picture</a></code>
-      element's area does not match the aspect ratio of the <a href="#image-resource">image
-      resource</a>, the <a href="#image-resource">image resource</a> will be shown
+      with the chosen <a href=#image-resource>image resource</a>'s intrinsic aspect ratio
+      being preserved. Thus, if the aspect ratio of the <a href=#dfn-picture><code>picture</code></a>
+      element's area does not match the aspect ratio of the <a href=#image-resource>image
+      resource</a>, the <a href=#image-resource>image resource</a> will be shown
       letterboxed or pillarboxed. Areas of the element's area that do not
-      contain the <a href="#image-resource">image resource</a> represent nothing.
+      contain the <a href=#image-resource>image resource</a> represent nothing.
     </p>
-    <div class="note">
-      <div class="note-title">
+    <div class=note>
+      <div class=note-title>
         <span>Note</span>
       </div>
       <div class="">
@@ -840,29 +945,29 @@ HTMLPictureElement : HTMLImageElement{
       </div>
     </div>
     <p>
-      For user agents that don't support the <code><a href="#dfn-picture">picture</a></code> element, an
-      author can provide an <code>img</code> element as <a href="#dfn-fallback-content">fallback
-      content</a>. User agents that support the <code><a href="#dfn-picture">picture</a></code> element
-      <em class="rfc2119" title="should not">should not</em> show this content
+      For user agents that don't support the <a href=#dfn-picture><code>picture</code></a> element, an
+      author can provide an <code>img</code> element as <a href=#dfn-fallback-content>fallback
+      content</a>. User agents that support the <a href=#dfn-picture><code>picture</code></a> element
+      <em title="should not" class=rfc2119>should not</em> show this content
       to the user: it is intended for legacy user agents that do not support
-      <code><a href="#dfn-picture">picture</a></code>, so that a legacy <code>img</code> element can be
+      <a href=#dfn-picture><code>picture</code></a>, so that a legacy <code>img</code> element can be
       shown instead.
     </p>
     <p>
       Authoring requirement: as with the <code>img</code> element, documents
-      must not use the <code><a href="#dfn-picture">picture</a></code> element as a layout tool. In
+      must not use the <a href=#dfn-picture><code>picture</code></a> element as a layout tool. In
       particular, picture elements should not be used to display
       transparent images, as they rarely convey meaning and rarely add anything
       useful to the document.
     </p>
     <p>
-      When used with the <code><a href="#dfn-picture">picture</a></code> element, a <span>document</span>
-      <em class="rfc2119" title="should">should</em> only contain
+      When used with the <a href=#dfn-picture><code>picture</code></a> element, a <span>document</span>
+      <em title=should class=rfc2119>should</em> only contain
       <code>source</code> elements need to represent the same subject matter,
       but cropping and zooming can differ.
     </p>
-    <div class="issue">
-      <div class="issue-title">
+    <div class=issue>
+      <div class=issue-title>
         <span>Issue 2</span>
       </div>
       <div class="">
@@ -874,90 +979,90 @@ HTMLPictureElement : HTMLImageElement{
     </div>
     <hr>
     <p>
-      The <code title="attr-hyperlink-usemap"><a href="#attr-hyperlink-usemap">usemap</a></code> attribute, if present, can
-      indicate that the image has an associated <a href="http://www.w3.org/TR/html5/embedded-content-0.html#image-map">image
+      The <code title=attr-hyperlink-usemap><a href=#attr-hyperlink-usemap>usemap</a></code> attribute, if present, can
+      indicate that the image has an associated <a href=http://www.w3.org/TR/html5/embedded-content-0.html#image-map>image
       map</a>.
     </p>
     <p>
-      The <dfn id="attr-picture-ismap" title="attr-picture-ismap"><code>ismap</code></dfn> attribute, when used on an
-      element that is a descendant of an <code><a href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
-      element with an <code title="attr-hyperlink-href"><a href="http://www.w3.org/TR/html5/links.html#attr-hyperlink-href">href</a></code>
+      The <dfn title=attr-picture-ismap id=attr-picture-ismap><code>ismap</code></dfn> attribute, when used on an
+      element that is a descendant of an <code><a href=http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element>a</a></code>
+      element with an <code title=attr-hyperlink-href><a href=http://www.w3.org/TR/html5/links.html#attr-hyperlink-href>href</a></code>
       attribute, indicates by its presence that the element provides access to
       a server-side image map. This affects how events are handled on the
-      corresponding <code><a href="http://www.w3.org/TR/html5/links.html#attr-hyperlink-href">a</a></code>
+      corresponding <code><a href=http://www.w3.org/TR/html5/links.html#attr-hyperlink-href>a</a></code>
       element.
     </p>
     <p>
-      The <code title="attr-picture-ismap"><a href="#attr-picture-ismap">ismap</a></code> attribute is a <a href="http://www.w3.org/TR/html5/infrastructure.html#boolean-attribute">boolean
+      The <code title=attr-picture-ismap><a href=#attr-picture-ismap>ismap</a></code> attribute is a <a href=http://www.w3.org/TR/html5/infrastructure.html#boolean-attribute>boolean
       attribute</a>. The attribute must not be specified on an element that
-      does not have an ancestor <code><a href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
-      element with an <code title="attr-hyperlink-href"><a href="http://www.w3.org/TR/html5/links.html#attr-hyperlink-href">href</a></code>
+      does not have an ancestor <code><a href=http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element>a</a></code>
+      element with an <code title=attr-hyperlink-href><a href=http://www.w3.org/TR/html5/links.html#attr-hyperlink-href>href</a></code>
       attribute.
     </p>
-    <div class="impl">
+    <div class=impl>
       <p>
-        The <dfn id="dom-picture-alt" title="dom-picture-alt"><code>alt</code></dfn>, <dfn id="dom-picture-src" title="dom-picture-src"><code>src</code></dfn>, <dfn id="dom-picture-srcset" title="dom-picture-srcset"><code>src</code></dfn>,
-        IDL attributes must <a href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a>
+        The <dfn title=dom-picture-alt id=dom-picture-alt><code>alt</code></dfn>, <dfn title=dom-picture-src id=dom-picture-src><code>src</code></dfn>, <dfn title=dom-picture-srcset id=dom-picture-srcset><code>src</code></dfn>,
+        IDL attributes must <a href=http://www.w3.org/TR/html5/infrastructure.html#reflect>reflect</a>
         the respective content attributes of the same name.
       </p>
       <p>
-        The <dfn id="dom-picture-crossorigin" title="dom-picture-crossOrigin"><code>crossOrigin</code></dfn> IDL attribute
-        must <a href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a>
-        the <code title="attr-picture-crossorigin"><a href="#attr-picture-crossorigin">crossorigin</a></code> content attribute.
+        The <dfn title=dom-picture-crossOrigin id=dom-picture-crossorigin><code>crossOrigin</code></dfn> IDL attribute
+        must <a href=http://www.w3.org/TR/html5/infrastructure.html#reflect>reflect</a>
+        the <code title=attr-picture-crossorigin><a href=#attr-picture-crossorigin>crossorigin</a></code> content attribute.
       </p>
       <p>
-        The <dfn id="dom-picture-usemap" title="dom-picture-useMap"><code>useMap</code></dfn> IDL attribute must
-        <a href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a>
-        the <code title="attr-hyperlink-usemap">usemap</code> content
+        The <dfn title=dom-picture-useMap id=dom-picture-usemap><code>useMap</code></dfn> IDL attribute must
+        <a href=http://www.w3.org/TR/html5/infrastructure.html#reflect>reflect</a>
+        the <code title=attr-hyperlink-usemap>usemap</code> content
         attribute.
       </p>
       <p>
-        The <dfn id="dom-picture-ismap" title="dom-picture-isMap"><code>isMap</code></dfn> IDL attribute must
-        <a href="http://www.w3.org/TR/html5/infrastructure.html#reflect">reflect</a>
-        the <code title="attr-picture-ismap"><a href="#attr-picture-ismap">ismap</a></code> content attribute.
+        The <dfn title=dom-picture-isMap id=dom-picture-ismap><code>isMap</code></dfn> IDL attribute must
+        <a href=http://www.w3.org/TR/html5/infrastructure.html#reflect>reflect</a>
+        the <code title=attr-picture-ismap><a href=#attr-picture-ismap>ismap</a></code> content attribute.
       </p>
-      <dl class="domintro">
+      <dl class=domintro>
         <dt>
-          <var><a href="#dfn-picture">picture</a></var> . <code title="dom-picture-load"><a href="#dom-picture-load">load()</a></code>
+          <var>picture</var> . <a href=#dom-picture-load><code title=dom-picture-load>load()</code></a>
         </dt>
         <dd>
           <p>
             Causes the element to reset and start selecting and loading a new
-            <a href="#image-resource">image resource</a> from scratch.
+            <a href=#image-resource>image resource</a> from scratch.
           </p>
         </dd>
       </dl>
-      <div class="impl">
+      <div class=impl>
         <p>
-          When the <dfn id="dom-picture-load" title="dom-picture-load"><code>load()</code></dfn>
-          method on a <code><a href="#dfn-picture">picture</a></code> element is invoked, the user agent
+          When the <dfn title=dom-picture-load id=dom-picture-load><code>load()</code></dfn>
+          method on a <a href=#dfn-picture><code>picture</code></a> element is invoked, the user agent
           must run the load algorithm.
         </p>
       </div>
     </div>
-    <h2 id="algorithm-for-deriving-the-source-image"><span class="secno">5 </span>
+    <h2 id=algorithm-for-deriving-the-source-image><span class=secno>5 </span>
       Algorithm for deriving the source image
     </h2>
     <p>
-      The <dfn id="dfn-algorithm-for-deriving-the-source-image">algorithm for
+      The <dfn id=dfn-algorithm-for-deriving-the-source-image>algorithm for
       deriving the source image</dfn> as follows. The result is the image
-      source to be used by the <code><a href="#dfn-picture">picture</a></code> element, which reflects the
-      <code><a href="#dfn-picture">picture</a></code> element's <span><code>src</code> IDL
+      source to be used by the <a href=#dfn-picture><code>picture</code></a> element, which reflects the
+      <a href=#dfn-picture><code>picture</code></a> element's <span><code>src</code> IDL
       attribute</span>:
     </p>
-    <div class="note">
-      <div class="note-title">
+    <div class=note>
+      <div class=note-title>
         <span>Note</span>
       </div>
       <div class="">
         <p>
-          What a <code><a href="#the-picture-element">picture</a></code>
-          element represents depends on the <code title="attr-picture-src"><a href="#attr-picture-src">src</a></code>
-          attribute, <code title="attr-picture-srcset"><a href="#attr-picture-srcset">srcset</a></code> attribute, the <code title="attr-picture-alt"><a href="#attr-picture-alt">alt</a></code>
+          What a <code><a href=#the-picture-element>picture</a></code>
+          element represents depends on the <code title=attr-picture-src><a href=#attr-picture-src>src</a></code>
+          attribute, <code title=attr-picture-srcset><a href=#attr-picture-srcset>srcset</a></code> attribute, the <code title=attr-picture-alt><a href=#attr-picture-alt>alt</a></code>
           attribute, and any child elements.
         </p>
         <p>
-          What we want to do is have the <code><a href="#dfn-picture">picture</a></code> behave exactly
+          What we want to do is have the <a href=#dfn-picture><code>picture</code></a> behave exactly
           the same as an <code>img</code> element, but with the only difference
           being that it is <code>source</code> elements is used to determine
           the value of the <code>src</code> IDL attribute (and hence what image
@@ -966,7 +1071,7 @@ HTMLPictureElement : HTMLImageElement{
           element.
         </p>
         <p>
-          So, to derive the <dfn id="dfn-source-image">source image</dfn>:
+          So, to derive the <dfn id=dfn-source-image>source image</dfn>:
           ignoring any sources whose <code>type</code> is not supported by the
           browser, gather all the media queries from the <code>source</code>
           elements' <code>media</code> attributes into a "stylesheet", in
@@ -975,14 +1080,14 @@ HTMLPictureElement : HTMLImageElement{
           queries are ignored. So, given the following:
         </p>
         <pre>&lt;picture id="pictureElement"&gt;
-<span class="example">   &lt;source media="(min-width: 45em)" srcset="large-1.jpg 1x, large-2.jpg 2x"&gt;
+<span class=example>   &lt;source media="(min-width: 45em)" srcset="large-1.jpg 1x, large-2.jpg 2x"&gt;
    &lt;source media="(min-width: 18em)" srcset="med-1.jpg 1x, med-2.jpg 2x"&gt;
 
    &lt;!-- assume media all --&gt;
    &lt;source srcset="small-1.jpg 1x, small-2.jpg 2x"&gt;</span>
 
    &lt;!-- the following are ignored --&gt;
-<span class="example">   &lt;source media=" is the message " srcset=""&gt;
+<span class=example>   &lt;source media=" is the message " srcset=""&gt;
       </span>
 &lt;/picture&gt;
 </pre>
@@ -993,19 +1098,19 @@ HTMLPictureElement : HTMLImageElement{
         <pre>//assume #pictureElement is magically scoped to the corresponding element.
 @media all{
    #pictureElement{
-      background-image: image-set(<span class="example">small-1.jpg 1x, small-2.jpg 2x</span>);
+      background-image: image-set(<span class=example>small-1.jpg 1x, small-2.jpg 2x</span>);
    }
 }
 
-@media<span class="example"> all and (min-width: 45em)</span>{
+@media<span class=example> all and (min-width: 45em)</span>{
    #pictureElement{
-      background-image: image-set(<span class="example">large-1.jpg 1x, large-2.jpg 2x</span>);
+      background-image: image-set(<span class=example>large-1.jpg 1x, large-2.jpg 2x</span>);
    }
 }
 
-@media <span class="example">all and </span><span class="example">(min-width: 18em)</span>{
+@media <span class=example>all and </span><span class=example>(min-width: 18em)</span>{
    #pictureElement{
-      background-image: image-set(<span class="example">med-1.jpg 1x, med-2.jpg 2x</span>);
+      background-image: image-set(<span class=example>med-1.jpg 1x, med-2.jpg 2x</span>);
    }
 }
 </pre>
@@ -1021,83 +1126,131 @@ HTMLPictureElement : HTMLImageElement{
       </div>
     </div>
     <p>
-      A user agent <em class="rfc2119" title="may">may</em> override requests
+      A user agent <em title=may class=rfc2119>may</em> override requests
       for higher-resolution images based on user preferences. For example:
       “always request high-resolution images,” “always request low-resolution
       images,” and “request high-resolution images as bandwidth permits” based
       on the bandwidth information available to the browser.
     </p>
     <p>
-      The <code title="attr-picture-alt"><a href="#attr-picture-alt">alt</a></code> attribute does not represent advisory
+      The <code title=attr-picture-alt><a href=#attr-picture-alt>alt</a></code> attribute does not represent advisory
       information. User agents must not present the contents of the
-      <code title="attr-picture-alt"><a href="#attr-picture-alt">alt</a></code>
-      attribute in the same way as content of the <code title="attr-title"><a href="dom.html#attr-title">title</a></code> attribute.
+      <code title=attr-picture-alt><a href=#attr-picture-alt>alt</a></code>
+      attribute in the same way as content of the <code title=attr-title><a href=dom.html#attr-title>title</a></code> attribute.
     </p>
-    <p class="warning">
-      While user agents are encouraged to repair cases of missing <code title="attr-picture-alt"><a href="#attr-picture-alt">alt</a></code> attributes,
-      authors must not rely on such behavior. <a href="http://www.w3.org/TR/html5/embedded-content-0.html#alt">Requirements for
+    <p class=warning>
+      While user agents are encouraged to repair cases of missing <code title=attr-picture-alt><a href=#attr-picture-alt>alt</a></code> attributes,
+      authors must not rely on such behavior. <a href=http://www.w3.org/TR/html5/embedded-content-0.html#alt>Requirements for
       providing text to act as an alternative for images</a> are described in
       detail in the <code>img</code> section.
     </p>
-    <h2 class="no-num" id="open-issues">
+    <h2 class=no-num id=open-issues>
       Open Issues
     </h2>
     <p>
-      We are tracking <dfn id="dfn-open-issues">open issues</dfn> on Github.
-      <a href="https://github.com/ResponsiveImagesCG/picture-element/issues">Please
+      We are tracking <dfn id=dfn-open-issues>open issues</dfn> on Github.
+      <a href=https://github.com/ResponsiveImagesCG/picture-element/issues>Please
       help close them</a>!
     </p>
-    <div id="open-issues-xhr"></div>
-    <h2 class="no-toc no-num" id="reference-implementations">
+    <div id=open-issues-xhr></div>
+    <h2 class="no-toc no-num" id=reference-implementations>
       Reference implementations
     </h2>
     <p>
-      We have a list of <a href="https://github.com/Wilto/draft-prop/wiki/Current-users,-polyfills,-prototypes,-and-implementations">
+      We have a list of <a href=https://github.com/Wilto/draft-prop/wiki/Current-users,-polyfills,-prototypes,-and-implementations>
       current users, polyfills, prototypes, and implementations</a> on Github.
     </p>
-    <h2 class="no-num" id="acknowledgements">
+    <h2 class=no-num id=acknowledgements>
       Acknowledgements
     </h2>
-    <p id="participants">
-      A <a href="http://www.w3.org/community/respimg/participants">complete
+    <p id=participants>
+      A <a href=http://www.w3.org/community/respimg/participants>complete
       list of participants</a> of the Responsive Images Community Group is
       available at the W3C Community Group Website.
     </p>
-    <h2 class="no-num" id="normative-references">
+    <p class=w3c>
+      <dfn id=participants-0>Participants</dfn> of the <a href=http://w3c.responsiveimages.org>Responsive Images Community Group</a>
+      at the time of publication were: George Adamson, Marie Alhomme, John
+      Allan, Joshua Allen, Angely Alvarez, Aaryn Anderson, Philip Andrews, Phil
+      Archer, Justin Avery, Michael Balensiefer, Toni Barrett, Bruno Barros,
+      Paul Barton, Adrian Bateman, Jesse Renée Beach, Robin Berjon, Seth
+      Bertalotto, Nicolaas Bijvoet, Andreas Bovens, J. Albert Bowden, Adam
+      Bradley, Rodrigo Brancher, Gordon Brander, Paul Bridgestock, Aaron
+      Brosey, Cory Brown, mairead buchan, Kris Bulman, Ariel Burone, Mathias
+      Bynens, Marcos Caceres, Rusty Calder, Ben Callahan, Loïc Calvy, Chuck
+      Carpenter, Brandon Carroll, Frederico Cerdeira, David Clements, Geri
+      Coady, Anne-Gaelle Colom, Cyril Concolato, Pete Correia, Andy Crum, Jason
+      Daihl, Francois Daoust, Kevin Davies, Robert Dawson, Ryan DeBeasi, Anna
+      Debenham, Darryl deHaan, David Demaree, George DeMet, Ian Devlin, peter
+      droogmans, Marlene Frykman, Dennis Gaebel, Nicolas Gallagher, Miguel
+      Garcia, Rafael Garcia Lepper, Larry Garfield, Peter Gasston, David Goss,
+      Chris Grant, Petra Gregorova, Jason Grigsby, Antoine Guergnon, Jeff
+      Guntle, Aaron Gustafson, Jason Haag, Patrick Haney, Anselm Hannemann,
+      chris hardy, Vincent Hardy, Dominique Hazaël-Massieux, Chris Hilditch,
+      Nathan Hinshaw, Sean Hintz, John Holt Ripley, Shane Hudson, Tomomi Imura,
+      Philip Ingrey, Brett Jankord, Scott Jehl, Dave Johnson, Nathanael Jones,
+      Michael Jovel, Chao Ju, Tim Kadlec, Frédéric Kayser, Jin Kim, Andreas
+      Klein, Peter Klein, John Kleinschmidt, Daniel Konopacki, Zoran Kurtin,
+      Gerardo Lagger, Adam Lake, Chris Lamothe, Tom Lane, Matthieu Larcher,
+      Bruce Lawson, Zach Leatherman, Silas Lepcha, Kornel Lesinski, Chris
+      Lilley, grappler login, Tania Lopes, André Luís, Jacine Luisi, David
+      Maciejewski, Kevin Mack, Ethan Malasky, Josh Marinacci, Eduardo Marques,
+      Mathew Marquis, Daniel Martínez, Tom Maslen, Jacob Mather, Chris
+      McAndrew, Denys Mishunov, Sabine Moebs, Ian Moffitt, Orestis Molopodis,
+      jason morita, David Moulton, Brian Muenzenmeyer, Emi Myoudou, Irakli
+      Nadareishvili, Christian Neuberger Jr, David Newton, Todd Nienkerk,
+      Kothary Nishant, Ashley Nolan, Kenneth Nordahl, Lewis Nyman, Alejandro
+      Oviedo, David Owens, Fernando Pasik, Andrew Pez Pengelly, Hassadee
+      Pimsuwan, Manik Rathee, François REMY, Nestor Rojas, Adrian Roselli,
+      Chris Ruppel, Oguzcan Sahin, Viljami Salminen, Luca Salvini, Luke Sands,
+      aron santa, Jad Sarout, Brandon Satrom, Christoph Saxe, Doug Schepers,
+      Jason Schmidt, Christopher Schmitt, Joe Schmitt, Boaz Sender, Tomoyuki
+      Shimizu, Ariel Shkedi, Jen Simmons, Katerina Skotalova, Michael[tm]
+      Smith, Ignacio Soriano Cano, Aaron Stanush, Jared Stilwell, Matt Stow,
+      Kevin Suttle, Satoru Takagi, Philipp Tautz, James Tudsbury, Jacob van
+      Zijp, Jitendra Vyas, Yoav Weiss, George White, Matt Wilcox, Richard Wild,
+      John Albin Wilkins, Owen Winkler, Jeremy Worboys, Mike Wu, Carlos Zepeda,
+      and jintian zheng.
+    </p>
+    <p class=w3c>
+      Contributions also from: Ilya Grigorik and Leon de Rijke.
+    </p>
+    <h2 class=no-num id=normative-references>
       Normative references
     </h2>
-    <dl class="bibliography">
-      <dt id="bib-CSS3-MEDIAQUERIES">
+    <dl class=bibliography>
+      <dt id=bib-CSS3-MEDIAQUERIES>
         [CSS3-MEDIAQUERIES]
       </dt>
       <dd>
-        <a href="http://www.w3.org/TR/css3-mediaqueries/"><cite>Media
-        Queries</cite></a>. (<a href="http://www.w3.org/TR/css3-mediaqueries/#status">status</a>).
+        <a href=http://www.w3.org/TR/css3-mediaqueries/><cite>Media
+        Queries</cite></a>. (<a href=http://www.w3.org/TR/css3-mediaqueries/#status>status</a>).
       </dd>
-      <dt id="bib-HTML5">
+      <dt id=bib-HTML5>
         [HTML]
       </dt>
       <dd>
-        <a href="http://dev.w3.org/html5/spec"><cite>HTML5.</cite></a>
-        (<a href="http://dev.w3.org/html5/spec#status-of-this-document">status</a>).
+        <a href=http://dev.w3.org/html5/spec><cite>HTML5.</cite></a>
+        (<a href=http://dev.w3.org/html5/spec#status-of-this-document>status</a>).
       </dd>
-      <dt id="bib-RFC2119">
+      <dt id=bib-RFC2119>
         [RFC2119]
       </dt>
       <dd>
-        <a href="http://www.ietf.org/rfc/rfc2119.txt"><cite>Key words for use
+        <a href=http://www.ietf.org/rfc/rfc2119.txt><cite>Key words for use
         in RFCs to Indicate Requirement Levels.</cite></a>
       </dd>
-      <dt id="bib-WEBIDL">
+      <dt id=bib-WEBIDL>
         [WEBIDL]
       </dt>
       <dd>
-        <a href="http://www.w3.org/TR/WebIDL/"><cite>Web IDL.</cite></a>
-        (<a href="http://www.w3.org/TR/WebIDL/#sotd">status</a>).
+        <a href=http://www.w3.org/TR/WebIDL/><cite>Web IDL.</cite></a>
+        (<a href=http://www.w3.org/TR/WebIDL/#sotd>status</a>).
       </dd>
-    </dl><script class="ricg" src="https://raw.github.com/ResponsiveImagesCG/meta/master/scripts/show_issues.js">
-</script> <script class="ricg" src="https://api.github.com/repos/ResponsiveImagesCG/picture-element/issues?state=open&amp;callback=processResponse">
-</script> <script class="ricg" src="https://raw.github.com/ResponsiveImagesCG/meta/master/scripts/ga.js">
+    </dl><script src=https://raw.github.com/ResponsiveImagesCG/meta/master/scripts/show_issues.js class=ricg>
+</script> <script src="https://api.github.com/repos/ResponsiveImagesCG/picture-element/issues?state=open&amp;callback=processResponse" class=ricg>
+</script> <script src=https://raw.github.com/ResponsiveImagesCG/meta/master/scripts/ga.js class=ricg>
 </script>
   
 
+</div></body></html>

--- a/index.src.html
+++ b/index.src.html
@@ -636,7 +636,7 @@ function closeWarning(element) {
    &lt;source media="(min-width: 45em)" src="large.jpg"&gt;
    &lt;source media="(min-width: 18em)" src="med.jpg"&gt;
    &lt;source src="small.jpg"&gt;
-   &lt;img src="small.jpg" alt=""&gt;
+   &lt;img src="small.jpg" alt="" lazyload&gt;
    &lt;p&gt;Accessible text&lt;/p&gt;
 &lt;/picture&gt;
 </pre>
@@ -669,11 +669,23 @@ function closeWarning(element) {
    &lt;source media="(min-width: 45em)" srcset="large-1.jpg 1x, large-2.jpg 2x"&gt;
    &lt;source media="(min-width: 18em)" srcset="med-1.jpg 1x, med-2.jpg 2x"&gt;
    &lt;source srcset="small-1.jpg 1x, small-2.jpg 2x"&gt;
-   &lt;img src="small-1.jpg" alt=""&gt;
+   &lt;img src="small-1.jpg" alt="" lazyload&gt;
    &lt;p&gt;Accessible text&lt;/p&gt;
 &lt;/picture&gt;
 </pre>
     </div>
+    <div class="note">
+      <div class="note-title">
+        <span>Note</span>
+      </div>
+      <div class="">
+        <p>
+        The <code>lazyload</code> attribute is used on the <code>&lt;img&gt;</code> tag in the above examples in order to avoid a download
+            of that resource when picture is supported.
+            It enables the user agent to delay the resource's download at least until the resource is added to the DOM, at which point the
+            user agent can detect that the <code>&lt;img&gt;</code> element is a child of a <code>&lt;picture&gt;</code> element.
+        </p>
+      </div>
     <h3>
       Relationship to <code>srcset</code>
     </h3>


### PR DESCRIPTION
In order to close https://github.com/ResponsiveImagesCG/picture-element/issues/5, I added the lazyload attribute to the fallback examples along with a note explaining why it should be there.

The note's language can probably be improved, and I'm not sure I did the anolis dance right, but it's a start.
