### PR TITLE
Note regarding @viewport and iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -1184,6 +1184,22 @@ Interaction with the Preload Scanner</span><a class=self-link href=#preloader></
 			or one which it cannot correctly determine the truth value of,
 			it must not attempt to preload <strong>any</strong> URL for the given <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element.
 	</ul>
+    <div class=note>
+        In some cases, the preload scanner cannot be aware of the final viewport’s dimensions when it encounters a <a data-link-type=element href=#elementdef-picture title=picture>picture</a> or a
+        <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
+        is when the preload scanner is operating on a <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element title=iframe>iframe</a> based document, which has its dimensions defined in an external
+        style-sheet.
+        <p>
+        Authors should be aware of these limitations, and should follow the following best practices:
+        <ul>
+            <li>
+                <span class=css data-link-type=maybe title=@viewport>@viewport</span> CSS rules should be defined inlined whenever viewport dependant resources need to be fetched as part of the
+                page’s loading.
+            <li>
+                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a class=css data-link-type=maybe href=http://dev.w3.org/csswg/css-writing-modes-3/#height title=height>height</a>
+                and <span class=css data-link-type=maybe title=weight>weight</span> attributes) or as inline CSS rules.
+        </ul>
+    </div>
 
 <h3 class="heading settled heading" data-level=3.3 id=picture-idl><span class=secno>3.3 </span><span class=content>
 <code>HTMLPictureElement</code> interface</span><a class=self-link href=#picture-idl></a></h3>

--- a/index.html
+++ b/index.html
@@ -1193,11 +1193,10 @@ Interaction with the Preload Scanner</span><a class=self-link href=#preloader></
         Authors should be aware of these limitations, and should follow the following best practices:
         <ul>
             <li>
-                <span class=css data-link-type=maybe title=@viewport>@viewport</span> CSS rules should be defined inlined whenever viewport dependant resources need to be fetched as part of the
-                page’s loading.
+                <span class=css data-link-type=maybe title=@viewport>@viewport</span> CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
+                page.
             <li>
-                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a class=css data-link-type=maybe href=http://dev.w3.org/csswg/css-writing-modes-3/#height title=height>height</a>
-                and <span class=css data-link-type=maybe title=weight>weight</span> attributes) or as inline CSS rules.
+                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a class=idl-code data-link-type=attribute title=height>height</a> and <a class=idl-code data-link-type=attribute href=http://dev.w3.org/csswg/css-font-load-events-3/#dom-fontface-weight title=weight>weight</a> attributes) or as inline CSS rules.
         </ul>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -546,14 +546,14 @@ span.issue, span.note {
 </p>
   <h1 class="p-name no-ref" id=title>The picture Element</h1>
   <h2 class="no-num no-toc no-ref heading settled heading" id=subtitle><span class=content>Editor’s Draft,
-    <span class=dt-updated><span class=value-title title=20140123>23 January 2014</span></span></span></h2>
+    <span class=dt-updated><span class=value-title title=20140124>24 January 2014</span></span></span></h2>
   <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Editor’s Draft:<dd><a href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Test Suite:<dd>None Yet<dt>Editors:
 <dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://xanthir.com/contact/>Tab Atkins</a> (<span class="p-org org">Google</span>)<dd class="p-author h-card vcard"><a class="p-name fn u-email email" href=mailto:>Marcos Cáceres</a> (<span class="p-org org">Mozilla</span>)<dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://matmarquis.com/>Mat Marquis</a><dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://blog.yoav.ws/>Yoav Weiss</a><dt>Version History:<dd><a href=https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages>Commit History</a><dd><a href=https://twitter.com/respimg_commits>Github commits on Twitter</a><dt>Participate:<dd><a href=http://w3c.responsiveimages.org>Join the Responsive Images Community Group</a><dd><a href=http://list.responsiveimages.org>Public Mailing List</a><dd><a href=irc://irc.w3.org:6665/#respimg>IRC: #respimg on W3C’s IRC</a><dd><a href=https://twitter.com/respimg>Twitter</a><dd><a href=https://github.com/ResponsiveImagesCG/picture-element>Github</a></dl></div>
   <div data-fill-with=warning></div>
   <p class=copyright data-fill-with=copyright><a href=http://creativecommons.org/publicdomain/zero/1.0/ rel=license><img alt=CC0 src=http://i.creativecommons.org/p/zero/1.0/80x15.png></a>
 To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 23 January 2014,
+In addition, as of 24 January 2014,
 the editors have made this specification available under the
 <a href=http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0 rel=license>Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
@@ -1186,17 +1186,18 @@ Interaction with the Preload Scanner</span><a class=self-link href=#preloader></
 	</ul>
 	<div class=note>
 		In some cases, the preload scanner or the parser cannot be aware of the final viewport’s dimensions when it encounters a <a data-link-type=element href=#elementdef-picture title=picture>picture</a> or a
-		<a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
+		<a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element. One example of such a case is when a @viewport definition is located in an external style-sheet. Another
 		is when the preload scanner is operating on a <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element title=iframe>iframe</a> based document, which has its dimensions defined in an external
 		style-sheet.
-		<p>
-		Authors should be aware of these limitations, and should follow the following best practices:
+
+<p>		Authors should be aware of these limitations, and should follow the following best practices:
 		<ul>
 			<li>
-				<span class=css data-link-type=maybe title=@viewport>@viewport</span> CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
+				@viewport CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
 				page.
 			<li>
-				iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a class=idl-code data-link-type=attribute title=height>height</a> and <a class=idl-code data-link-type=attribute href=http://dev.w3.org/csswg/css-font-load-events-3/#dom-fontface-weight title=weight>weight</a> attributes) or as inline CSS rules.
+				iframes that may contain viewport dependant resources should have their dimensions defined either in markup 
+                    (as <a data-link-for=iframe data-link-type=element-attr title=height>height</a> and <a data-link-for=iframe data-link-type=element-attr title=width>width</a> attributes) or as inline CSS rules.
 		</ul>
 	</div>
 

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ Interaction with the Preload Scanner</span><a class=self-link href=#preloader></
 			it must not attempt to preload <strong>any</strong> URL for the given <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element.
 	</ul>
     <div class=note>
-        In some cases, the preload scanner cannot be aware of the final viewport’s dimensions when it encounters a <a data-link-type=element href=#elementdef-picture title=picture>picture</a> or a
+        In some cases, the preload scanner or the parser cannot be aware of the final viewport’s dimensions when it encounters a <a data-link-type=element href=#elementdef-picture title=picture>picture</a> or a
         <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
         is when the preload scanner is operating on a <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element title=iframe>iframe</a> based document, which has its dimensions defined in an external
         style-sheet.

--- a/index.html
+++ b/index.html
@@ -1184,21 +1184,21 @@ Interaction with the Preload Scanner</span><a class=self-link href=#preloader></
 			or one which it cannot correctly determine the truth value of,
 			it must not attempt to preload <strong>any</strong> URL for the given <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element.
 	</ul>
-    <div class=note>
-        In some cases, the preload scanner or the parser cannot be aware of the final viewport’s dimensions when it encounters a <a data-link-type=element href=#elementdef-picture title=picture>picture</a> or a
-        <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
-        is when the preload scanner is operating on a <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element title=iframe>iframe</a> based document, which has its dimensions defined in an external
-        style-sheet.
-        <p>
-        Authors should be aware of these limitations, and should follow the following best practices:
-        <ul>
-            <li>
-                <span class=css data-link-type=maybe title=@viewport>@viewport</span> CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
-                page.
-            <li>
-                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a class=idl-code data-link-type=attribute title=height>height</a> and <a class=idl-code data-link-type=attribute href=http://dev.w3.org/csswg/css-font-load-events-3/#dom-fontface-weight title=weight>weight</a> attributes) or as inline CSS rules.
-        </ul>
-    </div>
+	<div class=note>
+		In some cases, the preload scanner or the parser cannot be aware of the final viewport’s dimensions when it encounters a <a data-link-type=element href=#elementdef-picture title=picture>picture</a> or a
+		<a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
+		is when the preload scanner is operating on a <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element title=iframe>iframe</a> based document, which has its dimensions defined in an external
+		style-sheet.
+		<p>
+		Authors should be aware of these limitations, and should follow the following best practices:
+		<ul>
+			<li>
+				<span class=css data-link-type=maybe title=@viewport>@viewport</span> CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
+				page.
+			<li>
+				iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a class=idl-code data-link-type=attribute title=height>height</a> and <a class=idl-code data-link-type=attribute href=http://dev.w3.org/csswg/css-font-load-events-3/#dom-fontface-weight title=weight>weight</a> attributes) or as inline CSS rules.
+		</ul>
+	</div>
 
 <h3 class="heading settled heading" data-level=3.3 id=picture-idl><span class=secno>3.3 </span><span class=content>
 <code>HTMLPictureElement</code> interface</span><a class=self-link href=#picture-idl></a></h3>

--- a/index.src.html
+++ b/index.src.html
@@ -645,18 +645,18 @@ Interaction with the Preload Scanner</h3>
 	</ul>
 	<div class='note'>
 		In some cases, the preload scanner or the parser cannot be aware of the final viewport's dimensions when it encounters a <a element>picture</a> or a
-		<a element>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
+		<a element>img</a> element. One example of such a case is when a @viewport definition is located in an external style-sheet. Another
 		is when the preload scanner is operating on a <a element>iframe</a> based document, which has its dimensions defined in an external
 		style-sheet.
-		<p>
+
 		Authors should be aware of these limitations, and should follow the following best practices:
 		<ul>
 			<li>
-				''@viewport'' CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
+				@viewport CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
 				page.
 			<li>
-				iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a
-					attribute>height</a> and <a attribute>weight</a> attributes) or as inline CSS rules.
+				iframes that may contain viewport dependant resources should have their dimensions defined either in markup 
+                    (as <a element-attr for=iframe>height</a> and <a element-attr for=iframe>width</a> attributes) or as inline CSS rules.
 		</ul>
 	</div>
 

--- a/index.src.html
+++ b/index.src.html
@@ -643,22 +643,22 @@ Interaction with the Preload Scanner</h3>
 			or one which it cannot correctly determine the truth value of,
 			it must not attempt to preload <strong>any</strong> URL for the given <a element>img</a> element.
 	</ul>
-    <div class='note'>
-        In some cases, the preload scanner or the parser cannot be aware of the final viewport's dimensions when it encounters a <a element>picture</a> or a
-        <a element>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
-        is when the preload scanner is operating on a <a element>iframe</a> based document, which has its dimensions defined in an external
-        style-sheet.
-        <p>
-        Authors should be aware of these limitations, and should follow the following best practices:
-        <ul>
-            <li>
-                ''@viewport'' CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
-                page.
-            <li>
-                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a
-                    attribute>height</a> and <a attribute>weight</a> attributes) or as inline CSS rules.
-        </ul>
-    </div>
+	<div class='note'>
+		In some cases, the preload scanner or the parser cannot be aware of the final viewport's dimensions when it encounters a <a element>picture</a> or a
+		<a element>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
+		is when the preload scanner is operating on a <a element>iframe</a> based document, which has its dimensions defined in an external
+		style-sheet.
+		<p>
+		Authors should be aware of these limitations, and should follow the following best practices:
+		<ul>
+			<li>
+				''@viewport'' CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
+				page.
+			<li>
+				iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a
+					attribute>height</a> and <a attribute>weight</a> attributes) or as inline CSS rules.
+		</ul>
+	</div>
 
 <h3 id='picture-idl'>
 <code>HTMLPictureElement</code> interface</h3>

--- a/index.src.html
+++ b/index.src.html
@@ -644,7 +644,7 @@ Interaction with the Preload Scanner</h3>
 			it must not attempt to preload <strong>any</strong> URL for the given <a element>img</a> element.
 	</ul>
     <div class='note'>
-        In some cases, the preload scanner cannot be aware of the final viewport's dimensions when it encounters a <a element>picture</a> or a
+        In some cases, the preload scanner or the parser cannot be aware of the final viewport's dimensions when it encounters a <a element>picture</a> or a
         <a element>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
         is when the preload scanner is operating on a <a element>iframe</a> based document, which has its dimensions defined in an external
         style-sheet.

--- a/index.src.html
+++ b/index.src.html
@@ -643,6 +643,22 @@ Interaction with the Preload Scanner</h3>
 			or one which it cannot correctly determine the truth value of,
 			it must not attempt to preload <strong>any</strong> URL for the given <a element>img</a> element.
 	</ul>
+    <div class='note'>
+        In some cases, the preload scanner cannot be aware of the final viewport's dimensions when it encounters a <a element>picture</a> or a
+        <a element>img</a> element. One example of such a case is when a '@viewport' definition is located in an external style-sheet. Another
+        is when the preload scanner is operating on a <a element>iframe</a> based document, which has its dimensions defined in an external
+        style-sheet.
+        <p>
+        Authors should be aware of these limitations, and should follow the following best practices:
+        <ul>
+            <li>
+                ''@viewport'' CSS rules should be defined inlined whenever viewport dependant resources need to be fetched as part of the
+                page's loading.
+            <li>
+                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as ''height''
+                and ''weight'' attributes) or as inline CSS rules.
+        </ul>
+    </div>
 
 <h3 id='picture-idl'>
 <code>HTMLPictureElement</code> interface</h3>

--- a/index.src.html
+++ b/index.src.html
@@ -652,11 +652,11 @@ Interaction with the Preload Scanner</h3>
         Authors should be aware of these limitations, and should follow the following best practices:
         <ul>
             <li>
-                ''@viewport'' CSS rules should be defined inlined whenever viewport dependant resources need to be fetched as part of the
-                page's loading.
+                ''@viewport'' CSS rules should be defined inline whenever viewport dependant resources need to be fetched as part of the
+                page.
             <li>
-                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as ''height''
-                and ''weight'' attributes) or as inline CSS rules.
+                iframes that may contain viewport dependant resources should have their dimensions defined either in markup (as <a
+                    attribute>height</a> and <a attribute>weight</a> attributes) or as inline CSS rules.
         </ul>
     </div>
 


### PR DESCRIPTION
Added a note stating that the parser/preloader may not be aware of final viewport dimensions when @viewport is used or when the resources are part of a dimension-less iframe.
Should close https://github.com/ResponsiveImagesCG/picture-element/issues/7
