### PR TITLE
Prevent code example from over-running container.

### DIFF
--- a/index.html
+++ b/index.html
@@ -813,7 +813,8 @@ Examples of usage</span><a class=self-link href=#examples></a></h3>
 		also be used on the <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element directly, removing the need for the
 		<a data-link-type=element href=#elementdef-picture title=picture>picture</a> and <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-source-element title=source>source</a> elements in simpler cases.
 
-		<pre>  &lt;img src="pic400.jpg" alt="The president giving an award." sizes="100%" srcset="pic400.jpg 400w, pic800.jpg 800w, pic1600.jpg 1600w"&gt;
+		<pre>  &lt;img src="pic400.jpg" alt="The president giving an award." sizes="100%" 
+			srcset="pic400.jpg 400w, pic800.jpg 800w, pic1600.jpg 1600w"&gt;
 </pre>	</div>
 
 <h3 class="heading settled heading" data-level=1.3 id=relationship-to-srcset><span class=secno>1.3 </span><span class=content>


### PR DESCRIPTION
This was running off the side of my browser on a desktop machine, so just put a line-break in the pre tag to tidy slightly.
