### PR TITLE
Define parsing of sizes in a way that doesn't require parsing the whole ...

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -553,7 +553,7 @@ Updating the Source Set</h4>
 
 						<li>
 							<a title="parse a sizes attribute">Parse <var>child</var>'s sizes attribute</a> and
-							let the returned <a>source set</a> be <var>source size</var>.
+							and let <var>source set</var>’s <a>source size</a> be the returned value.
 
 						<li>
 							If <var>child</var> has a <a element-attr for="img">src</a> attribute and <var>source set</var> does not contain a
@@ -829,10 +829,10 @@ Parsing a <code>sizes</code> Attribute</h4>
 			or the empty string if it's absent.
 
 		<li>
-			Let <var>component values</var> be an empty list.
+			Let <var>reached eof</var> be false.
 
 		<li>
-			Let <var>reached eof</var> be false.
+			<i title>New group</i>: Let <var>component values</var> be an empty list.
 
 		<li>
 			<i title>Consume</i>: If <var>reached eof</var> is true,
@@ -847,8 +847,12 @@ Parsing a <code>sizes</code> Attribute</h4>
 			let <var>reached eof</var> be true.
 
 		<li>
+			While the last item in <var>component values</var> is a <<whitespace-token>>,
+			remove it from <var>component values</var>.
+
+		<li>
 			If <var>component values</var> is empty,
-			jump back to the step labeled <i title>consume</i>.
+			jump back to the step labeled <i title>new group</i>.
 
 		<li>
 			Remove the last item from <var>component values</var>
@@ -857,19 +861,19 @@ Parsing a <code>sizes</code> Attribute</h4>
 		<li>
 			Parse <var>raw length</var> as a <<length>>
 			and let <var>length</var> be the result. [[!CSS3VAL]]
-			If this failed, jump to the step labeled <i title>consume</i>.
+			If this failed, jump to the step labeled <i title>new group</i>.
 
 		<li>
-			If <var>tokens</var> is empty, return <var>length</var> and abort these steps.
+			If <var>component values</var> is empty, return <var>length</var> and abort these steps.
 
 		<li>
-			Parse <var>tokens</var> as a <<media-condition>>
+			Parse <var>component values</var> as a <<media-condition>>
 			and let <var>media</var> be the result. [[!MEDIAQ]]
-			If this failed, jump to the step labeled <i title>consume</i>.
+			If this failed, jump to the step labeled <i title>new group</i>.
 
 		<li>
 			If <var>media</var> evaluates to false,
-			jump to the step labeled <i title>consume</i>.
+			jump to the step labeled <i title>new group</i>.
 
 		<li>
 			Return <var>length</var>.

--- a/index.bs
+++ b/index.bs
@@ -365,16 +365,14 @@ The <a element>picture</a> Element</h2>
 	An <a element>img</a> element is associated with a <a>source set</a>.
 
 	A <dfn export>source set</dfn> is a set of zero or more <a>image sources</a>,
-	optionally a <a>source size list</a>,
+	a <a>source size</a>,
 	and optionally a <a>media query</a>.
 
 	An <dfn export>image source</dfn> is a URL,
 	and optionally either a density descriptor,
 	or a width descriptor.
 
-	A <dfn export>source size list</dfn> is either an error or a list of
-	zero or more pairs of a <a>media query</a> and a <<length>>,
-	and optionally a default <<length>>.
+	A <dfn export>source size</dfn> is a <<length>>.
 
 	The <dfn>relevant mutations</dfn> for an <a element>img</a> element are as follows:
 
@@ -510,8 +508,7 @@ Selecting an Image Source</h4>
 			Let this be <var>selected source</var>.
 
 		<li>
-			The intrinsic width of <var>el</var> is the result of <a title="find the effective size">finding the effective size</a>
-			from <var>source list</var>.
+			The intrinsic width of <var>el</var> is <var>source set</var>'s <a>source size</a>.
 			The intrinsic resolution of <var>el</var> is the density associated with <var>selected source</var>.
 
 		<li>
@@ -555,15 +552,8 @@ Updating the Source Set</h4>
 							let <var>source set</var> be an empty <a>source set</a>.
 
 						<li>
-							If <var>child</var> has a <a element-attr for="img">sizes</a> attribute,
-							<a>parse its sizes attribute</a>
-							and let <var>source set</var>’s <a>source size list</a> be the returned value.
-							Otherwise,
-							let <var>source set</var>’s <a>source size list</a> be an empty <a>source size list</a>.
-
-						<li>
-							If the <var>source set</var>’s <a>source size list</a> is an error, let <var>source
-							set</var> be an empty <a>source set</a>.
+							<a title="parse a sizes attribute">Parse <var>child</var>'s sizes attribute</a> and
+							let the returned <a>source set</a> be <var>source size</var>.
 
 						<li>
 							If <var>child</var> has a <a element-attr for="img">src</a> attribute and <var>source set</var> does not contain a
@@ -603,15 +593,8 @@ Updating the Source Set</h4>
 					continue to the next child.
 
 				<li>
-					If <var>child</var> has a <a element-attr for="source">sizes</a> attribute,
-					<a>parse its sizes attribute</a>
-					and let <var>source set</var>’s <a>source size list</a> be the returned value.
-					Otherwise,
-					let <var>source set</var>’s <a>source size list</a> be an empty <a>source size list</a>.
-
-				<li>
-					If the <var>source set</var>’s <a>source size list</a> is an error, continue
-					to the next child.
+					<a title="parse its sizes attribute">Parse <var>child</var>'s sizes attribute</a>
+					and let <var>source set</var>’s <a>source size</a> be the returned value.
 
 				<li>
 					If <var>child</var> has a <a element-attr for="source">type</a> attribute,
@@ -838,39 +821,66 @@ Parsing a <code>srcset</code> Attribute</h4>
 Parsing a <code>sizes</code> Attribute</h4>
 
 	When asked to <dfn title="parse a sizes attribute|parse its sizes attribute">parse a sizes attribute</dfn> from an element,
-	parse the value of the element's <code>sizes</code> attribute with the following grammar:
+	run the following steps:
+
+	<ol>
+		<li>
+			Let <var>input</var> be the value of the element's sizes attribute,
+			or the empty string if it's absent.
+
+		<li>
+			Let <var>component values</var> be an empty list.
+
+		<li>
+			Let <var>reached eof</var> be false.
+
+		<li>
+			<i title>Consume</i>: If <var>reached eof</var> is true,
+			return ''300px'' and abort these steps.
+			Otherwise, <a spec=css-syntax>consume a component value</a> and let <var>component value</var> be the returned value. [[!CSS3SYN]]
+
+		<li>
+			If <var>component value</var> is not a <<comma-token>> or an <<eof-token>>,
+			append <var>component value</var> to <var>component values</var> and then
+			jump back to the step labeled <i title>consume</i>.
+			Otherwise, if <var>component value</var> is an <<eof-token>>,
+			let <var>reached eof</var> be true.
+
+		<li>
+			If <var>component values</var> is empty,
+			jump back to the step labeled <i title>consume</i>.
+
+		<li>
+			Remove the last item from <var>component values</var>
+			and let <var>raw length</var> be the removed item.
+
+		<li>
+			Parse <var>raw length</var> as a <<length>>
+			and let <var>length</var> be the result. [[!CSS3VAL]]
+			If this failed, jump to the step labeled <i title>consume</i>.
+
+		<li>
+			If <var>tokens</var> is empty, return <var>length</var> and abort these steps.
+
+		<li>
+			Parse <var>tokens</var> as a <<media-condition>>
+			and let <var>media</var> be the result. [[!MEDIAQ]]
+			If this failed, jump to the step labeled <i title>consume</i>.
+
+		<li>
+			If <var>media</var> evaluates to false,
+			jump to the step labeled <i title>consume</i>.
+
+		<li>
+			Return <var>length</var>.
+	</ol>
+
+	A <dfn export>valid source size list</dfn> is a string that matches the following grammar: [[!CSS3VAL]]
 
 	<pre>
 		<dfn>&lt;source-size-list></dfn> = <<source-size>>#?
 		<dfn>&lt;source-size></dfn> = <<media-condition>>? <<length>>
 	</pre>
-
-	The above grammar must be interpreted per the grammar definition in [[!CSS3VAL]].
-
-	If the value does not parse successfully according to the above grammar,
-	return an error.
-
-	Otherwise,
-	let <var>source size list</var> initially be an empty <a>source size list</a>.
-	For each <<source-size>> parsed,
-	do the following:
-
-	<ol>
-		<li>
-			If the parsed <<source-size>> does not contain a <<media-condition>>,
-			set <var>source size list</var>’s default size to the parsed <<length>>.
-			<span class='note'>This can be set multiple times; last wins.</span>
-			Continue to the next <<source-size>>.
-
-		<li>
-			If the <<media-condition>> evaluates to false,
-			continue to the next <<source-size>>.
-
-		<li>
-			Otherwise,
-			create a new pair of the parsed <<media-condition>> and the parsed <<length>>,
-			and append it to <var>source size list</var>.
-	</ol>
 
 <h4 id='normalize-source-densities'>
 Normalizing the Source Densities</h4>
@@ -885,11 +895,10 @@ Normalizing the Source Densities</h4>
 
 	<ol>
 		<li>
-			<a>Find the effective size</a> from <var>source set</var>’s <a>source size list</a>,
-			and let the result be <var>effective size</var>.
+			Let <var>source size</var> be <var>source set</var>’s <a>source size</a>.
 
 		<li>
-			For each <a>image source</a> in <var>source set</var>’s <a>source size list</a>:
+			For each <a>image source</a> in <var>source set</var>:
 
 			<ol>
 				<li>
@@ -899,7 +908,7 @@ Normalizing the Source Densities</h4>
 				<li>
 					Otherwise, if the <a>image source</a> has a size descriptor,
 					replace the size descriptor with a density descriptor
-					with a value of <code>size descriptor / effective size</code>
+					with a value of <code>size descriptor / source size</code>
 					and a unit of ''x''.
 
 				<li>
@@ -908,30 +917,6 @@ Normalizing the Source Densities</h4>
 			</ol>
 	</ol>
 
-
-<h4 id='find-effective-size'>
-Finding the Effective Size</h4>
-
-	When asked to <dfn>find the effective size</dfn> from a <a>source size list</a> <var>list</var>,
-	user agents must do the following:
-
-	<ol>
-		<li>
-			If <var>list</var> contains any <<media-query>>/<<length>> pairs,
-			find the first <<media-query>>, in pair order,
-			that evaluates to true.
-			If one was successfully found,
-			return the <<length>> from its pair.
-
-		<li>
-			Otherwise,
-			if <var>list</var> has a default size,
-			return that.
-
-		<li>
-			Otherwise,
-			return ''300px''.
-	</ol>
 
 <h3 id='preloader'>
 Interaction with the Preload Scanner</h3>
@@ -1000,7 +985,7 @@ Changes to the <a element>source</a> Element</h2>
 	The <a element>source</a> element, if it has a <a element>picture</a>
 	element as its parent, may also have the
 	<dfn element-attr for="source">sizes</dfn> attribute specified. If it is
-	specified, the value must match the <<source-size-list>> grammar.
+	specified, the value must be a <a>valid source size list</a>.
 
 	The <a element>source</a> element, if it has a <a element>picture</a>
 	element as its parent, may also have the
@@ -1054,7 +1039,7 @@ Changes to the <a element>img</a> Element</h2>
 	The <a element>img</a> element, if it has a
 	<a element-attr for="img">srcset</a> attribute, may have a
 	<dfn element-attr for="img">sizes</dfn> attribute specified. If it is
-	specified, the value must match the <<source-size-list>> grammar.
+	specified, the value must be a <a>valid source size list</a>.
 
 	The IDL attribute <a attribute for="HTMLImageElement">sizes</a> must
 	reflect the <a element-attr for="img">sizes</a> content attribute.

--- a/index.bs
+++ b/index.bs
@@ -864,7 +864,9 @@ Parsing a <code>sizes</code> Attribute</h4>
 			If this failed, jump to the step labeled <i title>new group</i>.
 
 		<li>
-			If <var>component values</var> is empty, return <var>length</var> and abort these steps.
+			If <var>component values</var> is empty
+			or consists of only <<whitespace-token>>s,
+			return <var>length</var> and abort these steps.
 
 		<li>
 			Parse <var>component values</var> as a <<media-condition>>

--- a/index.html
+++ b/index.html
@@ -552,14 +552,14 @@ span.issue, span.note {
 </p>
   <h1 class="p-name no-ref" id=title>The picture Element</h1>
   <h2 class="no-num no-toc no-ref heading settled heading" id=subtitle><span class=content>Editor’s Draft,
-    <span class=dt-updated><span class=value-title title=20140407>7 April 2014</span></span></span></h2>
+    <span class=dt-updated><span class=value-title title=20140408>8 April 2014</span></span></span></h2>
   <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Editor’s Draft:<dd><a href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Test Suite:<dd>None Yet<dt>Editors:
 <dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://xanthir.com/contact/>Tab Atkins</a> (<span class="p-org org">Google</span>)<dd class="p-author h-card vcard"><span class="p-name fn">Marcos Cáceres</span> (<span class="p-org org">Mozilla</span>)<dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://matmarquis.com/>Mat Marquis</a><dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://blog.yoav.ws/>Yoav Weiss</a><dd class="p-author h-card vcard"><a class="p-name fn u-email email" href=mailto:simonp@opera.com>Simon Pieters</a> (<span class="p-org org">Opera Software</span>)<dt>Version History:<dd><a href=https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages>Commit History</a><dd><a href=https://twitter.com/respimg_commits>Github commits on Twitter</a><dt>Participate:<dd><a href=http://w3c.responsiveimages.org>Join the Responsive Images Community Group</a><dd><a href=http://list.responsiveimages.org>Public Mailing List</a><dd><a href=irc://irc.w3.org:6665/#respimg>IRC: #respimg on W3C’s IRC</a><dd><a href=https://twitter.com/respimg>Twitter</a><dd><a href=https://github.com/ResponsiveImagesCG/picture-element>Github</a></dl></div>
   <div data-fill-with=warning></div>
   <p class=copyright data-fill-with=copyright><a href=http://creativecommons.org/publicdomain/zero/1.0/ rel=license><img alt=CC0 src=http://i.creativecommons.org/p/zero/1.0/80x15.png></a>
 To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 7 April 2014,
+In addition, as of 8 April 2014,
 the editors have made this specification available under the
 <a href=http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0 rel=license>Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
@@ -1102,7 +1102,7 @@ Updating the Source Set</span><a class=self-link href=#update-source-set></a></h
 
 						<li>
 							<a data-link-type=dfn href=#parse-a-sizes-attribute title="parse a sizes attribute">Parse <var>child</var>’s sizes attribute</a> and
-							let the returned <a data-link-type=dfn href=#source-set title="source set">source set</a> be <var>source size</var>.
+							and let <var>source set</var>’s <a data-link-type=dfn href=#source-size title="source size">source size</a> be the returned value.
 
 						<li>
 							If <var>child</var> has a <a data-link-for=img data-link-type=element-attr title=src>src</a> attribute and <var>source set</var> does not contain a
@@ -1378,10 +1378,10 @@ Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-size
 			or the empty string if it’s absent.
 
 		<li>
-			Let <var>component values</var> be an empty list.
+			Let <var>reached eof</var> be false.
 
 		<li>
-			Let <var>reached eof</var> be false.
+			<i title="">New group</i>: Let <var>component values</var> be an empty list.
 
 		<li>
 			<i title="">Consume</i>: If <var>reached eof</var> is true,
@@ -1396,8 +1396,12 @@ Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-size
 			let <var>reached eof</var> be true.
 
 		<li>
+			While the last item in <var>component values</var> is a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-whitespace-token title="<whitespace-token>">&lt;whitespace-token&gt;</a>,
+			remove it from <var>component values</var>.
+
+		<li>
 			If <var>component values</var> is empty,
-			jump back to the step labeled <i title="">consume</i>.
+			jump back to the step labeled <i title="">new group</i>.
 
 		<li>
 			Remove the last item from <var>component values</var>
@@ -1406,19 +1410,19 @@ Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-size
 		<li>
 			Parse <var>raw length</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>
 			and let <var>length</var> be the result. <a data-biblio-type=normative data-link-type=biblio href=#css3val title=css3val>[CSS3VAL]</a>
-			If this failed, jump to the step labeled <i title="">consume</i>.
+			If this failed, jump to the step labeled <i title="">new group</i>.
 
 		<li>
-			If <var>tokens</var> is empty, return <var>length</var> and abort these steps.
+			If <var>component values</var> is empty, return <var>length</var> and abort these steps.
 
 		<li>
-			Parse <var>tokens</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>
+			Parse <var>component values</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>
 			and let <var>media</var> be the result. <a data-biblio-type=normative data-link-type=biblio href=#mediaq title=mediaq>[MEDIAQ]</a>
-			If this failed, jump to the step labeled <i title="">consume</i>.
+			If this failed, jump to the step labeled <i title="">new group</i>.
 
 		<li>
 			If <var>media</var> evaluates to false,
-			jump to the step labeled <i title="">consume</i>.
+			jump to the step labeled <i title="">new group</i>.
 
 		<li>
 			Return <var>length</var>.

--- a/index.html
+++ b/index.html
@@ -552,14 +552,14 @@ span.issue, span.note {
 </p>
   <h1 class="p-name no-ref" id=title>The picture Element</h1>
   <h2 class="no-num no-toc no-ref heading settled heading" id=subtitle><span class=content>Editor’s Draft,
-    <span class=dt-updated><span class=value-title title=20140327>27 March 2014</span></span></span></h2>
+    <span class=dt-updated><span class=value-title title=20140407>7 April 2014</span></span></span></h2>
   <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Editor’s Draft:<dd><a href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Test Suite:<dd>None Yet<dt>Editors:
 <dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://xanthir.com/contact/>Tab Atkins</a> (<span class="p-org org">Google</span>)<dd class="p-author h-card vcard"><span class="p-name fn">Marcos Cáceres</span> (<span class="p-org org">Mozilla</span>)<dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://matmarquis.com/>Mat Marquis</a><dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://blog.yoav.ws/>Yoav Weiss</a><dd class="p-author h-card vcard"><a class="p-name fn u-email email" href=mailto:simonp@opera.com>Simon Pieters</a> (<span class="p-org org">Opera Software</span>)<dt>Version History:<dd><a href=https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages>Commit History</a><dd><a href=https://twitter.com/respimg_commits>Github commits on Twitter</a><dt>Participate:<dd><a href=http://w3c.responsiveimages.org>Join the Responsive Images Community Group</a><dd><a href=http://list.responsiveimages.org>Public Mailing List</a><dd><a href=irc://irc.w3.org:6665/#respimg>IRC: #respimg on W3C’s IRC</a><dd><a href=https://twitter.com/respimg>Twitter</a><dd><a href=https://github.com/ResponsiveImagesCG/picture-element>Github</a></dl></div>
   <div data-fill-with=warning></div>
   <p class=copyright data-fill-with=copyright><a href=http://creativecommons.org/publicdomain/zero/1.0/ rel=license><img alt=CC0 src=http://i.creativecommons.org/p/zero/1.0/80x15.png></a>
 To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 27 March 2014,
+In addition, as of 7 April 2014,
 the editors have made this specification available under the
 <a href=http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0 rel=license>Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
@@ -589,8 +589,7 @@ Parts of this work may be from another specification document.  If so, those par
 			<li><a href=#update-source-set><span class=secno>3.1.2</span> Updating the Source Set</a>
 			<li><a href=#parse-srcset-attr><span class=secno>3.1.3</span> Parsing a <code>srcset</code> Attribute</a>
 			<li><a href=#parse-sizes-attr><span class=secno>3.1.4</span> Parsing a <code>sizes</code> Attribute</a>
-			<li><a href=#normalize-source-densities><span class=secno>3.1.5</span> Normalizing the Source Densities</a>
-			<li><a href=#find-effective-size><span class=secno>3.1.6</span> Finding the Effective Size</a></ul>
+			<li><a href=#normalize-source-densities><span class=secno>3.1.5</span> Normalizing the Source Densities</a></ul>
 		<li><a href=#preloader><span class=secno>3.2</span> Interaction with the Preload Scanner</a>
 		<li><a href=#picture-idl><span class=secno>3.3</span> <code>HTMLPictureElement</code> interface</a></ul>
 	<li><a href=#the-source-element><span class=secno>4</span> Changes to the <span data-link-type=element title=source>source</span> Element</a>
@@ -915,16 +914,14 @@ Attributes: Global attributes
 <p>	An <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element is associated with a <a data-link-type=dfn href=#source-set title="source set">source set</a>.
 
 <p>	A <dfn data-dfn-type=dfn data-export="" id=source-set>source set<a class=self-link href=#source-set></a></dfn> is a set of zero or more <a data-link-type=dfn href=#image-source title="image sources">image sources</a>,
-	optionally a <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a>,
+	a <a data-link-type=dfn href=#source-size title="source size">source size</a>,
 	and optionally a <a data-link-type=dfn href=http://dev.w3.org/csswg/mediaqueries-4/#media-query title="media query">media query</a>.
 
 <p>	An <dfn data-dfn-type=dfn data-export="" id=image-source>image source<a class=self-link href=#image-source></a></dfn> is a URL,
 	and optionally either a density descriptor,
 	or a width descriptor.
 
-<p>	A <dfn data-dfn-type=dfn data-export="" id=source-size-list>source size list<a class=self-link href=#source-size-list></a></dfn> is either an error or a list of
-	zero or more pairs of a <a data-link-type=dfn href=http://dev.w3.org/csswg/mediaqueries-4/#media-query title="media query">media query</a> and a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>,
-	and optionally a default <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>.
+<p>	A <dfn data-dfn-type=dfn data-export="" id=source-size>source size<a class=self-link href=#source-size></a></dfn> is a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>.
 
 <p>	The <dfn data-dfn-type=dfn data-noexport="" id=relevant-mutations>relevant mutations<a class=self-link href=#relevant-mutations></a></dfn> for an <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element are as follows:
 
@@ -1060,8 +1057,7 @@ Selecting an Image Source</span><a class=self-link href=#select-image-source></a
 			Let this be <var>selected source</var>.
 
 		<li>
-			The intrinsic width of <var>el</var> is the result of <a data-link-type=dfn href=#find-the-effective-size title="find the effective size">finding the effective size</a>
-			from <var>source list</var>.
+			The intrinsic width of <var>el</var> is <var>source set</var>’s <a data-link-type=dfn href=#source-size title="source size">source size</a>.
 			The intrinsic resolution of <var>el</var> is the density associated with <var>selected source</var>.
 
 		<li>
@@ -1105,15 +1101,8 @@ Updating the Source Set</span><a class=self-link href=#update-source-set></a></h
 							let <var>source set</var> be an empty <a data-link-type=dfn href=#source-set title="source set">source set</a>.
 
 						<li>
-							If <var>child</var> has a <a data-link-for=img data-link-type=element-attr href=#element-attrdef-sizes title=sizes>sizes</a> attribute,
-							<a data-link-type=dfn href=#parse-a-sizes-attribute title="parse its sizes attribute">parse its sizes attribute</a>
-							and let <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> be the returned value.
-							Otherwise,
-							let <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> be an empty <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a>.
-
-						<li>
-							If the <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> is an error, let <var>source
-							set</var> be an empty <a data-link-type=dfn href=#source-set title="source set">source set</a>.
+							<a data-link-type=dfn href=#parse-a-sizes-attribute title="parse a sizes attribute">Parse <var>child</var>’s sizes attribute</a> and
+							let the returned <a data-link-type=dfn href=#source-set title="source set">source set</a> be <var>source size</var>.
 
 						<li>
 							If <var>child</var> has a <a data-link-for=img data-link-type=element-attr title=src>src</a> attribute and <var>source set</var> does not contain a
@@ -1153,15 +1142,8 @@ Updating the Source Set</span><a class=self-link href=#update-source-set></a></h
 					continue to the next child.
 
 				<li>
-					If <var>child</var> has a <a data-link-for=source data-link-type=element-attr href=#element-attrdef-sizes0 title=sizes>sizes</a> attribute,
-					<a data-link-type=dfn href=#parse-a-sizes-attribute title="parse its sizes attribute">parse its sizes attribute</a>
-					and let <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> be the returned value.
-					Otherwise,
-					let <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> be an empty <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a>.
-
-				<li>
-					If the <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> is an error, continue
-					to the next child.
+					<a data-link-type=dfn href=#parse-a-sizes-attribute title="parse its sizes attribute">Parse <var>child</var>’s sizes attribute</a>
+					and let <var>source set</var>’s <a data-link-type=dfn href=#source-size title="source size">source size</a> be the returned value.
 
 				<li>
 					If <var>child</var> has a <a data-link-for=source data-link-type=element-attr href=#element-attrdef-type title=type>type</a> attribute,
@@ -1388,38 +1370,65 @@ Parsing a <code>srcset</code> Attribute</span><a class=self-link href=#parse-src
 Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-sizes-attr></a></h4>
 
 <p>	When asked to <dfn data-dfn-type=dfn data-noexport="" id=parse-a-sizes-attribute title="parse a sizes attribute|parse its sizes attribute">parse a sizes attribute<a class=self-link href=#parse-a-sizes-attribute></a></dfn> from an element,
-	parse the value of the element’s <code>sizes</code> attribute with the following grammar:
+	run the following steps:
+
+	<ol>
+		<li>
+			Let <var>input</var> be the value of the element’s sizes attribute,
+			or the empty string if it’s absent.
+
+		<li>
+			Let <var>component values</var> be an empty list.
+
+		<li>
+			Let <var>reached eof</var> be false.
+
+		<li>
+			<i title="">Consume</i>: If <var>reached eof</var> is true,
+			return <span class=css data-link-type=maybe title=300px>300px</span> and abort these steps.
+			Otherwise, <a data-link-spec=css-syntax data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#consume-a-component-value0 title="consume a component value">consume a component value</a> and let <var>component value</var> be the returned value. <a data-biblio-type=normative data-link-type=biblio href=#css3syn title=css3syn>[CSS3SYN]</a>
+
+		<li>
+			If <var>component value</var> is not a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-comma-token title="<comma-token>">&lt;comma-token&gt;</a> or an <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-eof-token title="<eof-token>">&lt;eof-token&gt;</a>,
+			append <var>component value</var> to <var>component values</var> and then
+			jump back to the step labeled <i title="">consume</i>.
+			Otherwise, if <var>component value</var> is an <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-eof-token title="<eof-token>">&lt;eof-token&gt;</a>,
+			let <var>reached eof</var> be true.
+
+		<li>
+			If <var>component values</var> is empty,
+			jump back to the step labeled <i title="">consume</i>.
+
+		<li>
+			Remove the last item from <var>component values</var>
+			and let <var>raw length</var> be the removed item.
+
+		<li>
+			Parse <var>raw length</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>
+			and let <var>length</var> be the result. <a data-biblio-type=normative data-link-type=biblio href=#css3val title=css3val>[CSS3VAL]</a>
+			If this failed, jump to the step labeled <i title="">consume</i>.
+
+		<li>
+			If <var>tokens</var> is empty, return <var>length</var> and abort these steps.
+
+		<li>
+			Parse <var>tokens</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>
+			and let <var>media</var> be the result. <a data-biblio-type=normative data-link-type=biblio href=#mediaq title=mediaq>[MEDIAQ]</a>
+			If this failed, jump to the step labeled <i title="">consume</i>.
+
+		<li>
+			If <var>media</var> evaluates to false,
+			jump to the step labeled <i title="">consume</i>.
+
+		<li>
+			Return <var>length</var>.
+	</ol>
+
+<p>	A <dfn data-dfn-type=dfn data-export="" id=valid-source-size-list>valid source size list<a class=self-link href=#valid-source-size-list></a></dfn> is a string that matches the following grammar: <a data-biblio-type=normative data-link-type=biblio href=#css3val title=css3val>[CSS3VAL]</a>
 
 	<pre>  <dfn class=css-code data-dfn-type=type data-export="" id=typedef-source-size-list>&lt;source-size-list&gt;<a class=self-link href=#typedef-source-size-list></a></dfn> = <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a>#?
   <dfn class=css-code data-dfn-type=type data-export="" id=typedef-source-size>&lt;source-size&gt;<a class=self-link href=#typedef-source-size></a></dfn> = <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>? <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>
 </pre>
-<p>	The above grammar must be interpreted per the grammar definition in <a data-biblio-type=normative data-link-type=biblio href=#css3val title=css3val>[CSS3VAL]</a>.
-
-<p>	If the value does not parse successfully according to the above grammar,
-	return an error.
-
-<p>	Otherwise,
-	let <var>source size list</var> initially be an empty <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a>.
-	For each <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a> parsed,
-	do the following:
-
-	<ol>
-		<li>
-			If the parsed <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a> does not contain a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>,
-			set <var>source size list</var>’s default size to the parsed <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>.
-			<span class=note>This can be set multiple times; last wins.</span>
-			Continue to the next <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a>.
-
-		<li>
-			If the <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a> evaluates to false,
-			continue to the next <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a>.
-
-		<li>
-			Otherwise,
-			create a new pair of the parsed <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a> and the parsed <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>,
-			and append it to <var>source size list</var>.
-	</ol>
-
 <h4 class="heading settled heading" data-level=3.1.5 id=normalize-source-densities><span class=secno>3.1.5 </span><span class=content>
 Normalizing the Source Densities</span><a class=self-link href=#normalize-source-densities></a></h4>
 
@@ -1433,11 +1442,10 @@ Normalizing the Source Densities</span><a class=self-link href=#normalize-source
 
 	<ol>
 		<li>
-			<a data-link-type=dfn href=#find-the-effective-size title="find the effective size">Find the effective size</a> from <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a>,
-			and let the result be <var>effective size</var>.
+			Let <var>source size</var> be <var>source set</var>’s <a data-link-type=dfn href=#source-size title="source size">source size</a>.
 
 		<li>
-			For each <a data-link-type=dfn href=#image-source title="image source">image source</a> in <var>source set</var>’s <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a>:
+			For each <a data-link-type=dfn href=#image-source title="image source">image source</a> in <var>source set</var>:
 
 			<ol>
 				<li>
@@ -1447,7 +1455,7 @@ Normalizing the Source Densities</span><a class=self-link href=#normalize-source
 				<li>
 					Otherwise, if the <a data-link-type=dfn href=#image-source title="image source">image source</a> has a size descriptor,
 					replace the size descriptor with a density descriptor
-					with a value of <code>size descriptor / effective size</code>
+					with a value of <code>size descriptor / source size</code>
 					and a unit of <span class=css data-link-type=maybe title=x>x</span>.
 
 				<li>
@@ -1456,30 +1464,6 @@ Normalizing the Source Densities</span><a class=self-link href=#normalize-source
 			</ol>
 	</ol>
 
-
-<h4 class="heading settled heading" data-level=3.1.6 id=find-effective-size><span class=secno>3.1.6 </span><span class=content>
-Finding the Effective Size</span><a class=self-link href=#find-effective-size></a></h4>
-
-<p>	When asked to <dfn data-dfn-type=dfn data-noexport="" id=find-the-effective-size>find the effective size<a class=self-link href=#find-the-effective-size></a></dfn> from a <a data-link-type=dfn href=#source-size-list title="source size list">source size list</a> <var>list</var>,
-	user agents must do the following:
-
-	<ol>
-		<li>
-			If <var>list</var> contains any <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-query title="<media-query>">&lt;media-query&gt;</a>/<a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a> pairs,
-			find the first <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-query title="<media-query>">&lt;media-query&gt;</a>, in pair order,
-			that evaluates to true.
-			If one was successfully found,
-			return the <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a> from its pair.
-
-		<li>
-			Otherwise,
-			if <var>list</var> has a default size,
-			return that.
-
-		<li>
-			Otherwise,
-			return <span class=css data-link-type=maybe title=300px>300px</span>.
-	</ol>
 
 <h3 class="heading settled heading" data-level=3.2 id=preloader><span class=secno>3.2 </span><span class=content>
 Interaction with the Preload Scanner</span><a class=self-link href=#preloader></a></h3>
@@ -1546,7 +1530,7 @@ Changes to the <a data-link-type=element href=http://www.w3.org/html/wg/drafts/h
 <p>	The <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-source-element title=source>source</a> element, if it has a <a data-link-type=element href=#elementdef-picture title=picture>picture</a>
 	element as its parent, may also have the
 	<dfn data-dfn-for=source data-dfn-type=element-attr data-export="" id=element-attrdef-sizes0>sizes<a class=self-link href=#element-attrdef-sizes0></a></dfn> attribute specified. If it is
-	specified, the value must match the <a class="production css-code" data-link-type=type href=#typedef-source-size-list title="<source-size-list>">&lt;source-size-list&gt;</a> grammar.
+	specified, the value must be a <a data-link-type=dfn href=#valid-source-size-list title="valid source size list">valid source size list</a>.
 
 <p>	The <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-source-element title=source>source</a> element, if it has a <a data-link-type=element href=#elementdef-picture title=picture>picture</a>
 	element as its parent, may also have the
@@ -1598,7 +1582,7 @@ Changes to the <a data-link-type=element href=http://www.w3.org/html/wg/drafts/h
 <p>	The <a data-link-type=element href=http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-img-element title=img>img</a> element, if it has a
 	<a data-link-for=img data-link-type=element-attr title=srcset>srcset</a> attribute, may have a
 	<dfn data-dfn-for=img data-dfn-type=element-attr data-export="" id=element-attrdef-sizes>sizes<a class=self-link href=#element-attrdef-sizes></a></dfn> attribute specified. If it is
-	specified, the value must match the <a class="production css-code" data-link-type=type href=#typedef-source-size-list title="<source-size-list>">&lt;source-size-list&gt;</a> grammar.
+	specified, the value must be a <a data-link-type=dfn href=#valid-source-size-list title="valid source size list">valid source size list</a>.
 
 <p>	The IDL attribute <a class=idl-code data-link-for=HTMLImageElement data-link-type=attribute href=#dom-htmlimageelement-sizes title=sizes>sizes</a> must
 	reflect the <a data-link-for=img data-link-type=element-attr href=#element-attrdef-sizes title=sizes>sizes</a> content attribute.
@@ -1654,7 +1638,7 @@ References</span><a class=self-link href=#references></a></h2>
 
 <h3 class="no-num no-ref heading settled heading" id=normative><span class=content>
 Normative References</span><a class=self-link href=#normative></a></h3>
-<div data-fill-with=normative-references><dl><dt id=css3val title=CSS3VAL><a class=self-link href=#css3val></a>[CSS3VAL]<dd>Håkon Wium Lie; Tab Atkins; Elika J. Etemad. <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>CSS Values and Units Module Level 3</a>. 30 July 2013. W3C Candidate Recommendation. (Work in progress.) URL: <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>http://www.w3.org/TR/2013/CR-css3-values-20130730/</a><dt id=html title=HTML><a class=self-link href=#html></a>[HTML]<dd>Ian Hickson. <a href=http://whatwg.org/html>HTML</a>. Living Standard. URL: <a href=http://whatwg.org/html>http://whatwg.org/html</a><dt id=mediaq title=MEDIAQ><a class=self-link href=#mediaq></a>[MEDIAQ]<dd>Florian Rivoal. <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>Media Queries</a>. 19 June 2012. W3C Recommendation. URL: <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/</a><dt id=rfc2119 title=RFC2119><a class=self-link href=#rfc2119></a>[RFC2119]<dd>S. Bradner. <a href=http://www.ietf.org/rfc/rfc2119.txt>Key words for use in RFCs to Indicate Requirement Levels</a>. URL: <a href=http://www.ietf.org/rfc/rfc2119.txt>http://www.ietf.org/rfc/rfc2119.txt</a><dt id=respimg-usecases title=respimg-usecases><a class=self-link href=#respimg-usecases></a>[respimg-usecases]<dd>Marcos Cáceres; et al. <a href=http://www.w3.org/TR/respimg-usecases/>Use Cases and Requirements for Standardizing Responsive Images</a>. NOTE. URL: <a href=http://www.w3.org/TR/respimg-usecases/>http://www.w3.org/TR/respimg-usecases/</a></dl></div>
+<div data-fill-with=normative-references><dl><dt id=css3syn title=CSS3SYN><a class=self-link href=#css3syn></a>[CSS3SYN]<dd>Tab Atkins Jr.; Simon Sapin. <a href=http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/>CSS Syntax Module</a>. 5 November 2013. W3C Working Draft. (Work in progress.) URL: <a href=http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/>http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/</a><dt id=css3val title=CSS3VAL><a class=self-link href=#css3val></a>[CSS3VAL]<dd>Håkon Wium Lie; Tab Atkins; Elika J. Etemad. <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>CSS Values and Units Module Level 3</a>. 30 July 2013. W3C Candidate Recommendation. (Work in progress.) URL: <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>http://www.w3.org/TR/2013/CR-css3-values-20130730/</a><dt id=html title=HTML><a class=self-link href=#html></a>[HTML]<dd>Ian Hickson. <a href=http://whatwg.org/html>HTML</a>. Living Standard. URL: <a href=http://whatwg.org/html>http://whatwg.org/html</a><dt id=mediaq title=MEDIAQ><a class=self-link href=#mediaq></a>[MEDIAQ]<dd>Florian Rivoal. <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>Media Queries</a>. 19 June 2012. W3C Recommendation. URL: <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/</a><dt id=rfc2119 title=RFC2119><a class=self-link href=#rfc2119></a>[RFC2119]<dd>S. Bradner. <a href=http://www.ietf.org/rfc/rfc2119.txt>Key words for use in RFCs to Indicate Requirement Levels</a>. URL: <a href=http://www.ietf.org/rfc/rfc2119.txt>http://www.ietf.org/rfc/rfc2119.txt</a><dt id=respimg-usecases title=respimg-usecases><a class=self-link href=#respimg-usecases></a>[respimg-usecases]<dd>Marcos Cáceres; et al. <a href=http://www.w3.org/TR/respimg-usecases/>Use Cases and Requirements for Standardizing Responsive Images</a>. NOTE. URL: <a href=http://www.w3.org/TR/respimg-usecases/>http://www.w3.org/TR/respimg-usecases/</a></dl></div>
 
 <h3 class="no-num no-ref heading settled heading" id=informative><span class=content>
 Informative References</span><a class=self-link href=#informative></a></h3>
@@ -1664,7 +1648,6 @@ Informative References</span><a class=self-link href=#informative></a></h3>
 Index</span><a class=self-link href=#index></a></h2>
 <div data-fill-with=index><ul class=indexlist>
 <li>collect a sequence of characters, <a href=#dfn-collect-a-sequence-of-characters title="section 2">2</a>
-<li>find the effective size, <a href=#find-the-effective-size title="section 3.1.6">3.1.6</a>
 <li>HTMLPictureElement, <a href=#dom-htmlpictureelement title="section 3.3">3.3</a>
 <li>image candidate string, <a href=#image-candidate-string title="section 3.1.3">3.1.3</a>
 <li>image source, <a href=#image-source title="section 3">3</a>
@@ -1685,9 +1668,9 @@ Index</span><a class=self-link href=#index></a></h2>
 <li>attribute for HTMLImageElement, <a href=#dom-htmlimageelement-sizes title="section 5">5</a>
 </ul><li>skip whitespace, <a href=#dfn-skip-whitespace title="section 2">2</a>
 <li>source set, <a href=#source-set title="section 3">3</a>
+<li>source size, <a href=#source-size title="section 3">3</a>
 <li>&lt;source-size&gt;, <a href=#typedef-source-size title="section 3.1.4">3.1.4</a>
 <li>&lt;source-size-list&gt;, <a href=#typedef-source-size-list title="section 3.1.4">3.1.4</a>
-<li>source size list, <a href=#source-size-list title="section 3">3</a>
 <li>space character, <a href=#dfn-space-character title="section 2">2</a>
 <li>split a string on spaces, <a href=#dfn-split-a-string-on-spaces title="section 2">2</a>
 <li>srcset<ul><li>element-attr for source, <a href=#element-attrdef-srcset title="section 4">4</a>
@@ -1699,6 +1682,7 @@ Index</span><a class=self-link href=#index></a></h2>
 <li>valid media query, <a href=#dfn-valid-media-query title="section 2">2</a>
 <li>valid non-empty URL, <a href=#dfn-valid-non-empty-url title="section 2">2</a>
 <li>valid non-negative integer, <a href=#dfn-valid-non-negative-integer title="section 2">2</a>
+<li>valid source size list, <a href=#valid-source-size-list title="section 3.1.4">3.1.4</a>
 </ul></div>
 
 <h2 class="no-num no-ref heading settled heading" id=property-index><span class=content>

--- a/index.html
+++ b/index.html
@@ -1413,7 +1413,9 @@ Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-size
 			If this failed, jump to the step labeled <i title="">new group</i>.
 
 		<li>
-			If <var>component values</var> is empty, return <var>length</var> and abort these steps.
+			If <var>component values</var> is empty
+			or consists of only <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-whitespace-token title="<whitespace-token>">&lt;whitespace-token&gt;</a>s,
+			return <var>length</var> and abort these steps.
 
 		<li>
 			Parse <var>component values</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>


### PR DESCRIPTION
...attribute. Fixes #136 Fixes #135

This also removes the behavior of skipping `source` when `sizes` is invalid, since @yoavweiss wanted to avoid distinguishing between an invalid query and one that doesn't match.
