### PR TITLE
Don't set intrinsic width from sizes since that's bogus. Don't set the i...

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -512,10 +512,6 @@ Selecting an Image Source</h4>
 			Let this be <var>selected source</var>.
 
 		<li>
-			The intrinsic width of <var>el</var> is <var>source set</var>'s <a>source size</a>.
-			The intrinsic resolution of <var>el</var> is the density associated with <var>selected source</var>.
-
-		<li>
 			Return <var>selected source</var> and its associated pixel density.
 	</ol>
 

--- a/index.html
+++ b/index.html
@@ -1061,10 +1061,6 @@ Selecting an Image Source</span><a class=self-link href=#select-image-source></a
 			Let this be <var>selected source</var>.
 
 		<li>
-			The intrinsic width of <var>el</var> is <var>source set</var>’s <a data-link-type=dfn href=#source-size title="source size">source size</a>.
-			The intrinsic resolution of <var>el</var> is the density associated with <var>selected source</var>.
-
-		<li>
 			Return <var>selected source</var> and its associated pixel density.
 	</ol>
 


### PR DESCRIPTION
...ntrinsic resolution here; we return the density and the HTML spec handles the resolution with 'current pixel density'. Fixes #121 Fixes #107

(We may want to return the w/h descriptors too as part of #85.)
