### PR TITLE
Simplify language of the sizes parsing algo.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -871,9 +871,12 @@ Parsing a <code>sizes</code> Attribute</h4>
 			continue to the next iteration of this algorithm.
 
 		<li>
-			If all remaining <a>component values</a> in <var>unparsed size</var>
+			If this is the final <var>unparsed size</var> in <var>unparsed sizes list</var>
+			and all remaining <a>component values</a> in <var>unparsed size</var>
 			are <<whitespace-token>>s,
 			return <var>size</var> and exit this algorithm.
+			Otherwise,
+			continue to the next iteration of this algorithm.
 
 		<li>
 			Parse the remaining <a>component values</a> in <var>unparsed size</var>

--- a/index.bs
+++ b/index.bs
@@ -842,17 +842,6 @@ Parsing a <code>sizes</code> Attribute</h4>
 	(or the empty string, if the attribute is absent),
 	and let <var>unparsed sizes list</var> be the result.
 
-	<strong>Simplest algo</strong>
-
-	Attempt to parse each entry of <var>unparsed sizes list</var> as a <<source-size>>,
-	or, for the last entry, as either a <<source-size>> or a <<source-size-value>>.
-	For the first one that parses successfully,
-	return the value of the <<source-size-value>> so parsed.
-	If no entry parses successfully,
-	return ''100vw''.
-
-	<strong>Slightly more complex algo</strong>
-
 	For each <var>unparsed size</var> in <var>unparsed sizes list</var>:
 
 	<ol>

--- a/index.bs
+++ b/index.bs
@@ -838,67 +838,56 @@ Parsing a <code>srcset</code> Attribute</h4>
 Parsing a <code>sizes</code> Attribute</h4>
 
 	When asked to <dfn title="parse a sizes attribute|parse its sizes attribute">parse a sizes attribute</dfn> from an element,
-	run the following steps:
+	<a>parse a comma-separated list of component values</a> from the value of the element's <a element-attr title>sizes</a> attribute
+	(or the empty string, if the attribute is absent),
+	and let <var>unparsed sizes list</var> be the result.
+
+	<strong>Simplest algo</strong>
+
+	Attempt to parse each entry of <var>unparsed sizes list</var> as a <<source-size>>,
+	or, for the last entry, as either a <<source-size>> or a <<source-size-value>>.
+	For the first one that parses successfully,
+	return the value of the <<source-size-value>> so parsed.
+	If no entry parses successfully,
+	return ''100vw''.
+
+	<strong>Slightly more complex algo</strong>
+
+	For each <var>unparsed size</var> in <var>unparsed sizes list</var>:
 
 	<ol>
 		<li>
-			Let <var>input</var> be the value of the element's sizes attribute,
-			or the empty string if it's absent.
+			Remove all consecutive <<whitespace-token>>s
+			from the end of <var>unparsed size</var>.
+			If this removes <em>all</em> the tokens from <var>unparsed size</var>,
+			continue to the next iteration of this algorithm.
 
 		<li>
-			Let <var>reached eof</var> be false.
+			If the last <a>component value</a> in <var>unparsed size</var>
+			is a valid positive <<source-size-value>>,
+			let <var>size</var> be its value
+			and remove the <a>component value</a> from <var>unparsed size</var>.
+			Otherwise,
+			continue to the next iteration of this algorithm.
 
 		<li>
-			<i title>New group</i>: Let <var>component values</var> be an empty list.
+			If all remaining <a>component values</a> in <var>unparsed size</var>
+			are <<whitespace-token>>s,
+			return <var>size</var> and exit this algorithm.
 
 		<li>
-			<i title>Consume</i>: If <var>reached eof</var> is true,
-			return ''100vw'' and abort these steps.
-			Otherwise, <a spec=css-syntax>consume a component value</a> and let <var>component value</var> be the returned value. [[!CSS3SYN]]
+			Parse the remaining <a>component values</a> in <var>unparsed size</var>
+			as a <<media-condition>>.
+			If it does not parse correctly,
+			or it does parse correctly but the <<media-condition>> evaluates to false,
+			continue to the next iteration of this algorithm.
 
 		<li>
-			If <var>component value</var> is not a <<comma-token>> or an <<eof-token>>,
-			append <var>component value</var> to <var>component values</var> and then
-			jump back to the step labeled <i title>consume</i>.
-			Otherwise, if <var>component value</var> is an <<eof-token>>,
-			let <var>reached eof</var> be true.
-
-		<li>
-			While the last item in <var>component values</var> is a <<whitespace-token>>,
-			remove it from <var>component values</var>.
-
-		<li>
-			If <var>component values</var> is empty,
-			jump back to the step labeled <i title>new group</i>.
-
-		<li>
-			Remove the last item from <var>component values</var>
-			and let <var>raw size</var> be the removed item.
-
-		<li>
-			Parse <var>raw size</var> as a <<source-size-value>>
-			and let <var>size</var> be the result. [[!CSS3VAL]]
-			If this failed,
-			or if <var>size</var> is negative or zero,
-			jump to the step labeled <i title>new group</i>.
-
-		<li>
-			If <var>component values</var> is empty
-			or consists of only <<whitespace-token>>s,
-			return <var>size</var> and abort these steps.
-
-		<li>
-			Parse <var>component values</var> as a <<media-condition>>
-			and let <var>media</var> be the result. [[!MEDIAQ]]
-			If this failed, jump to the step labeled <i title>new group</i>.
-
-		<li>
-			If <var>media</var> evaluates to false,
-			jump to the step labeled <i title>new group</i>.
-
-		<li>
-			Return <var>size</var>.
+			Return <var>size</var> and exit this algorithm.
 	</ol>
+
+	If the above algorithm exhausts <var>unparsed sizes list</var> without returning a <var>size</var> value,
+	return ''100vw''.
 
 	A <dfn export>valid source size list</dfn> is a string that matches the following grammar: [[!CSS3VAL]]
 

--- a/index.bs
+++ b/index.bs
@@ -848,7 +848,7 @@ Parsing a <code>sizes</code> Attribute</h4>
 		<li>
 			Remove all consecutive <<whitespace-token>>s
 			from the end of <var>unparsed size</var>.
-			If this removes <em>all</em> the tokens from <var>unparsed size</var>,
+			If <var>unparsed size</var> is now empty,
 			continue to the next iteration of this algorithm.
 
 		<li>

--- a/index.bs
+++ b/index.bs
@@ -853,7 +853,7 @@ Parsing a <code>sizes</code> Attribute</h4>
 
 		<li>
 			If the last <a>component value</a> in <var>unparsed size</var>
-			is a valid positive <<source-size-value>>,
+			is a valid non-negative non-zero <<source-size-value>>,
 			let <var>size</var> be its value
 			and remove the <a>component value</a> from <var>unparsed size</var>.
 			Otherwise,

--- a/index.bs
+++ b/index.bs
@@ -842,6 +842,16 @@ Parsing a <code>sizes</code> Attribute</h4>
 	(or the empty string, if the attribute is absent),
 	and let <var>unparsed sizes list</var> be the result.
 
+	<strong>Simplest algo</strong>
+
+	Attempt to parse each entry of <var>unparsed sizes list</var> as a <<source-size>> or <<source-size-value>>.
+	For the first one that parses successfully,
+	return the value of the <<source-size-value>> so parsed.
+	If no entry parses successfully,
+	return ''100vw''.
+
+	<strong>Slightly more complex algo</strong>
+
 	For each <var>unparsed size</var> in <var>unparsed sizes list</var>:
 
 	<ol>
@@ -860,12 +870,9 @@ Parsing a <code>sizes</code> Attribute</h4>
 			continue to the next iteration of this algorithm.
 
 		<li>
-			If this is the final <var>unparsed size</var> in <var>unparsed sizes list</var>
-			and all remaining <a>component values</a> in <var>unparsed size</var>
+			If all remaining <a>component values</a> in <var>unparsed size</var>
 			are <<whitespace-token>>s,
 			return <var>size</var> and exit this algorithm.
-			Otherwise,
-			continue to the next iteration of this algorithm.
 
 		<li>
 			Parse the remaining <a>component values</a> in <var>unparsed size</var>
@@ -890,6 +897,15 @@ Parsing a <code>sizes</code> Attribute</h4>
 	</pre>
 
 	A <<source-size-value>> must not be negative and must not be zero.
+
+	Note: While a <a>valid source size list</a> only contains a bare <<source-size-value>>
+	(without an accompanying <<media-condition>>)
+	as the last entry in the <<source-size-list>>,
+	the parsing algorithm technically allows such at any point in the list,
+	and will accept it immediately as the size
+	if the preceding entries in the list weren't used.
+	This is to enable future extensions,
+	and protect against simple author errors such as a final trailing comma.
 
 <h4 id='normalize-source-densities'>
 Normalizing the Source Densities</h4>

--- a/index.bs
+++ b/index.bs
@@ -842,16 +842,6 @@ Parsing a <code>sizes</code> Attribute</h4>
 	(or the empty string, if the attribute is absent),
 	and let <var>unparsed sizes list</var> be the result.
 
-	<strong>Simplest algo</strong>
-
-	Attempt to parse each entry of <var>unparsed sizes list</var> as a <<source-size>> or <<source-size-value>>.
-	For the first one that parses successfully,
-	return the value of the <<source-size-value>> so parsed.
-	If no entry parses successfully,
-	return ''100vw''.
-
-	<strong>Slightly more complex algo</strong>
-
 	For each <var>unparsed size</var> in <var>unparsed sizes list</var>:
 
 	<ol>

--- a/index.html
+++ b/index.html
@@ -552,14 +552,14 @@ span.issue, span.note {
 </p>
   <h1 class="p-name no-ref" id=title>The picture Element</h1>
   <h2 class="no-num no-toc no-ref heading settled heading" id=subtitle><span class=content>Editor’s Draft,
-    <span class=dt-updated><span class=value-title title=20140411>11 April 2014</span></span></span></h2>
+    <span class=dt-updated><span class=value-title title=20140414>14 April 2014</span></span></span></h2>
   <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Editor’s Draft:<dd><a href=http://picture.responsiveimages.org>http://picture.responsiveimages.org</a><dt>Test Suite:<dd>None Yet<dt>Editors:
 <dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://xanthir.com/contact/>Tab Atkins</a> (<span class="p-org org">Google</span>)<dd class="p-author h-card vcard"><span class="p-name fn">Marcos Cáceres</span> (<span class="p-org org">Mozilla</span>)<dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://matmarquis.com/>Mat Marquis</a><dd class="p-author h-card vcard"><a class="p-name fn u-url url" href=http://blog.yoav.ws/>Yoav Weiss</a><dd class="p-author h-card vcard"><a class="p-name fn u-email email" href=mailto:simonp@opera.com>Simon Pieters</a> (<span class="p-org org">Opera Software</span>)<dt>Version History:<dd><a href=https://github.com/ResponsiveImagesCG/picture-element/commits/gh-pages>Commit History</a><dd><a href=https://twitter.com/respimg_commits>Github commits on Twitter</a><dt>Participate:<dd><a href=http://w3c.responsiveimages.org>Join the Responsive Images Community Group</a><dd><a href=http://list.responsiveimages.org>Public Mailing List</a><dd><a href=irc://irc.w3.org:6665/#respimg>IRC: #respimg on W3C’s IRC</a><dd><a href=https://twitter.com/respimg>Twitter</a><dd><a href=https://github.com/ResponsiveImagesCG/picture-element>Github</a></dl></div>
   <div data-fill-with=warning></div>
   <p class=copyright data-fill-with=copyright><a href=http://creativecommons.org/publicdomain/zero/1.0/ rel=license><img alt=CC0 src=http://i.creativecommons.org/p/zero/1.0/80x15.png></a>
 To the extent possible under law, the editors have waived all copyright
 and related or neighboring rights to this work.
-In addition, as of 11 April 2014,
+In addition, as of 14 April 2014,
 the editors have made this specification available under the
 <a href=http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0 rel=license>Open Web Foundation Agreement Version 1.0</a>,
 which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
@@ -1382,67 +1382,56 @@ Parsing a <code>srcset</code> Attribute</span><a class=self-link href=#parse-src
 Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-sizes-attr></a></h4>
 
 <p>	When asked to <dfn data-dfn-type=dfn data-noexport="" id=parse-a-sizes-attribute title="parse a sizes attribute|parse its sizes attribute">parse a sizes attribute<a class=self-link href=#parse-a-sizes-attribute></a></dfn> from an element,
-	run the following steps:
+	<a data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#parse-a-comma-separated-list-of-component-values0 title="parse a comma-separated list of component values">parse a comma-separated list of component values</a> from the value of the element’s <a data-link-type=element-attr title="">sizes</a> attribute
+	(or the empty string, if the attribute is absent),
+	and let <var>unparsed sizes list</var> be the result.
+
+<p>	<strong>Simplest algo</strong>
+
+<p>	Attempt to parse each entry of <var>unparsed sizes list</var> as a <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a>,
+	or, for the last entry, as either a <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a> or a <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a>.
+	For the first one that parses successfully,
+	return the value of the <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a> so parsed.
+	If no entry parses successfully,
+	return <span class=css data-link-type=maybe title=100vw>100vw</span>.
+
+<p>	<strong>Slightly more complex algo</strong>
+
+<p>	For each <var>unparsed size</var> in <var>unparsed sizes list</var>:
 
 	<ol>
 		<li>
-			Let <var>input</var> be the value of the element’s sizes attribute,
-			or the empty string if it’s absent.
+			Remove all consecutive <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-whitespace-token title="<whitespace-token>">&lt;whitespace-token&gt;</a>s
+			from the end of <var>unparsed size</var>.
+			If this removes <em>all</em> the tokens from <var>unparsed size</var>,
+			continue to the next iteration of this algorithm.
 
 		<li>
-			Let <var>reached eof</var> be false.
+			If the last <a data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#component-value title="component value">component value</a> in <var>unparsed size</var>
+			is a valid positive <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a>,
+			let <var>size</var> be its value
+			and remove the <a data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#component-value title="component value">component value</a> from <var>unparsed size</var>.
+			Otherwise,
+			continue to the next iteration of this algorithm.
 
 		<li>
-			<i title="">New group</i>: Let <var>component values</var> be an empty list.
+			If all remaining <a data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#component-value title="component values">component values</a> in <var>unparsed size</var>
+			are <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-whitespace-token title="<whitespace-token>">&lt;whitespace-token&gt;</a>s,
+			return <var>size</var> and exit this algorithm.
 
 		<li>
-			<i title="">Consume</i>: If <var>reached eof</var> is true,
-			return <span class=css data-link-type=maybe title=100vw>100vw</span> and abort these steps.
-			Otherwise, <a data-link-spec=css-syntax data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#consume-a-component-value0 title="consume a component value">consume a component value</a> and let <var>component value</var> be the returned value. <a data-biblio-type=normative data-link-type=biblio href=#css3syn title=css3syn>[CSS3SYN]</a>
+			Parse the remaining <a data-link-type=dfn href=http://dev.w3.org/csswg/css-syntax-3/#component-value title="component values">component values</a> in <var>unparsed size</var>
+			as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>.
+			If it does not parse correctly,
+			or it does parse correctly but the <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a> evaluates to false,
+			continue to the next iteration of this algorithm.
 
 		<li>
-			If <var>component value</var> is not a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-comma-token title="<comma-token>">&lt;comma-token&gt;</a> or an <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-eof-token title="<eof-token>">&lt;eof-token&gt;</a>,
-			append <var>component value</var> to <var>component values</var> and then
-			jump back to the step labeled <i title="">consume</i>.
-			Otherwise, if <var>component value</var> is an <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-eof-token title="<eof-token>">&lt;eof-token&gt;</a>,
-			let <var>reached eof</var> be true.
-
-		<li>
-			While the last item in <var>component values</var> is a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-whitespace-token title="<whitespace-token>">&lt;whitespace-token&gt;</a>,
-			remove it from <var>component values</var>.
-
-		<li>
-			If <var>component values</var> is empty,
-			jump back to the step labeled <i title="">new group</i>.
-
-		<li>
-			Remove the last item from <var>component values</var>
-			and let <var>raw size</var> be the removed item.
-
-		<li>
-			Parse <var>raw size</var> as a <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a>
-			and let <var>size</var> be the result. <a data-biblio-type=normative data-link-type=biblio href=#css3val title=css3val>[CSS3VAL]</a>
-			If this failed,
-			or if <var>size</var> is negative or zero,
-			jump to the step labeled <i title="">new group</i>.
-
-		<li>
-			If <var>component values</var> is empty
-			or consists of only <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-syntax-3/#typedef-whitespace-token title="<whitespace-token>">&lt;whitespace-token&gt;</a>s,
-			return <var>size</var> and abort these steps.
-
-		<li>
-			Parse <var>component values</var> as a <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>
-			and let <var>media</var> be the result. <a data-biblio-type=normative data-link-type=biblio href=#mediaq title=mediaq>[MEDIAQ]</a>
-			If this failed, jump to the step labeled <i title="">new group</i>.
-
-		<li>
-			If <var>media</var> evaluates to false,
-			jump to the step labeled <i title="">new group</i>.
-
-		<li>
-			Return <var>size</var>.
+			Return <var>size</var> and exit this algorithm.
 	</ol>
+
+<p>	If the above algorithm exhausts <var>unparsed sizes list</var> without returning a <var>size</var> value,
+	return <span class=css data-link-type=maybe title=100vw>100vw</span>.
 
 <p>	A <dfn data-dfn-type=dfn data-export="" id=valid-source-size-list>valid source size list<a class=self-link href=#valid-source-size-list></a></dfn> is a string that matches the following grammar: <a data-biblio-type=normative data-link-type=biblio href=#css3val title=css3val>[CSS3VAL]</a>
 
@@ -1672,7 +1661,7 @@ References</span><a class=self-link href=#references></a></h2>
 
 <h3 class="no-num no-ref heading settled heading" id=normative><span class=content>
 Normative References</span><a class=self-link href=#normative></a></h3>
-<div data-fill-with=normative-references><dl><dt id=css3syn title=CSS3SYN><a class=self-link href=#css3syn></a>[CSS3SYN]<dd>Tab Atkins Jr.; Simon Sapin. <a href=http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/>CSS Syntax Module</a>. 5 November 2013. W3C Working Draft. (Work in progress.) URL: <a href=http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/>http://www.w3.org/TR/2013/WD-css-syntax-3-20131105/</a><dt id=css3val title=CSS3VAL><a class=self-link href=#css3val></a>[CSS3VAL]<dd>Håkon Wium Lie; Tab Atkins; Elika J. Etemad. <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>CSS Values and Units Module Level 3</a>. 30 July 2013. W3C Candidate Recommendation. (Work in progress.) URL: <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>http://www.w3.org/TR/2013/CR-css3-values-20130730/</a><dt id=html title=HTML><a class=self-link href=#html></a>[HTML]<dd>Ian Hickson. <a href=http://whatwg.org/html>HTML</a>. Living Standard. URL: <a href=http://whatwg.org/html>http://whatwg.org/html</a><dt id=mediaq title=MEDIAQ><a class=self-link href=#mediaq></a>[MEDIAQ]<dd>Florian Rivoal. <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>Media Queries</a>. 19 June 2012. W3C Recommendation. URL: <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/</a><dt id=rfc2119 title=RFC2119><a class=self-link href=#rfc2119></a>[RFC2119]<dd>S. Bradner. <a href=http://www.ietf.org/rfc/rfc2119.txt>Key words for use in RFCs to Indicate Requirement Levels</a>. URL: <a href=http://www.ietf.org/rfc/rfc2119.txt>http://www.ietf.org/rfc/rfc2119.txt</a><dt id=respimg-usecases title=respimg-usecases><a class=self-link href=#respimg-usecases></a>[respimg-usecases]<dd>Marcos Cáceres; et al. <a href=http://www.w3.org/TR/respimg-usecases/>Use Cases and Requirements for Standardizing Responsive Images</a>. NOTE. URL: <a href=http://www.w3.org/TR/respimg-usecases/>http://www.w3.org/TR/respimg-usecases/</a></dl></div>
+<div data-fill-with=normative-references><dl><dt id=css3val title=CSS3VAL><a class=self-link href=#css3val></a>[CSS3VAL]<dd>Håkon Wium Lie; Tab Atkins; Elika J. Etemad. <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>CSS Values and Units Module Level 3</a>. 30 July 2013. W3C Candidate Recommendation. (Work in progress.) URL: <a href=http://www.w3.org/TR/2013/CR-css3-values-20130730/>http://www.w3.org/TR/2013/CR-css3-values-20130730/</a><dt id=html title=HTML><a class=self-link href=#html></a>[HTML]<dd>Ian Hickson. <a href=http://whatwg.org/html>HTML</a>. Living Standard. URL: <a href=http://whatwg.org/html>http://whatwg.org/html</a><dt id=mediaq title=MEDIAQ><a class=self-link href=#mediaq></a>[MEDIAQ]<dd>Florian Rivoal. <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>Media Queries</a>. 19 June 2012. W3C Recommendation. URL: <a href=http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/>http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/</a><dt id=rfc2119 title=RFC2119><a class=self-link href=#rfc2119></a>[RFC2119]<dd>S. Bradner. <a href=http://www.ietf.org/rfc/rfc2119.txt>Key words for use in RFCs to Indicate Requirement Levels</a>. URL: <a href=http://www.ietf.org/rfc/rfc2119.txt>http://www.ietf.org/rfc/rfc2119.txt</a><dt id=respimg-usecases title=respimg-usecases><a class=self-link href=#respimg-usecases></a>[respimg-usecases]<dd>Marcos Cáceres; et al. <a href=http://www.w3.org/TR/respimg-usecases/>Use Cases and Requirements for Standardizing Responsive Images</a>. NOTE. URL: <a href=http://www.w3.org/TR/respimg-usecases/>http://www.w3.org/TR/respimg-usecases/</a></dl></div>
 
 <h3 class="no-num no-ref heading settled heading" id=informative><span class=content>
 Informative References</span><a class=self-link href=#informative></a></h3>

--- a/index.html
+++ b/index.html
@@ -1388,8 +1388,7 @@ Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-size
 
 <p>	<strong>Simplest algo</strong>
 
-<p>	Attempt to parse each entry of <var>unparsed sizes list</var> as a <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a>,
-	or, for the last entry, as either a <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a> or a <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a>.
+<p>	Attempt to parse each entry of <var>unparsed sizes list</var> as a <a class="production css-code" data-link-type=type href=#typedef-source-size title="<source-size>">&lt;source-size&gt;</a> or <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a>.
 	For the first one that parses successfully,
 	return the value of the <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a> so parsed.
 	If no entry parses successfully,
@@ -1440,6 +1439,15 @@ Parsing a <code>sizes</code> Attribute</span><a class=self-link href=#parse-size
   <dfn class=css-code data-dfn-type=type data-export="" id=typedef-source-size-value>&lt;source-size-value&gt;<a class=self-link href=#typedef-source-size-value></a></dfn> = <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/css-values-3/#length-value title="<length>">&lt;length&gt;</a>
 </pre>
 <p>	A <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a> must not be negative and must not be zero.
+
+<p class=note>	Note: While a <a data-link-type=dfn href=#valid-source-size-list title="valid source size list">valid source size list</a> only contains a bare <a class="production css-code" data-link-type=type href=#typedef-source-size-value title="<source-size-value>">&lt;source-size-value&gt;</a>
+	(without an accompanying <a class="production css-code" data-link-type=type href=http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-condition title="<media-condition>">&lt;media-condition&gt;</a>)
+	as the last entry in the <a class="production css-code" data-link-type=type href=#typedef-source-size-list title="<source-size-list>">&lt;source-size-list&gt;</a>,
+	the parsing algorithm technically allows such at any point in the list,
+	and will accept it immediately as the size
+	if the preceding entries in the list weren’t used.
+	This is to enable future extensions,
+	and protect against simple author errors such as a final trailing comma.
 
 <h4 class="heading settled heading" data-level=3.1.5 id=normalize-source-densities><span class=secno>3.1.5 </span><span class=content>
 Normalizing the Source Densities</span><a class=self-link href=#normalize-source-densities></a></h4>


### PR DESCRIPTION
Rewrite the sizes parsing algo into a more readable form, without losing any precision.

Currently the branch contains two alternate algorithms, one more prose-y, one more algo-y.  We need to choose which one we prefer before this can be merged.
